### PR TITLE
BE/#21 프로젝트 글의 내용 검색 기능 구현

### DIFF
--- a/backend/src/main/java/com/graphy/backend/BackendApplication.java
+++ b/backend/src/main/java/com/graphy/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package com.graphy.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
@@ -66,14 +66,19 @@ public class ProjectController {
      */
     @Operation(summary = "findProjects", description = "(default: 전체 조회) 제목으로 프로젝트 검색")
     @GetMapping("")
-    public ResponseEntity<ResultResponse> getProjectByName(@RequestParam(required = false) String projectName,
-                                                           @PageableDefault(direction = Sort.Direction.DESC) Pageable page) {
-        if (projectName == null) {
-            List<GetProjectResponse> result = projectService.getProjects(page);
-            return ResponseEntity.ok(ResultResponse.of(ResultCode.PROJECT_PAGING_GET_SUCCESS, result));
+    public ResponseEntity<ResultResponse> getProjects(@RequestParam(required = false) String projectName, @RequestParam(required = false) String content,
+                                                      @PageableDefault(sort = {"createdAt"}, direction = Sort.Direction.DESC) Pageable page) {
+
+        List<GetProjectResponse> result;
+
+        if (projectName != null) {
+            result = projectService.getProjectByName(projectName, page);
+        } else if (content != null) {
+            result = projectService.getProjectByContent(content, page);
+        } else {
+            result = projectService.getProjects(page);
         }
 
-        List<GetProjectResponse> result = projectService.getProjectByName(projectName, page);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.PROJECT_GET_SUCCESS, result));
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/repository/ProjectRepository.java
@@ -8,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
     Page<Project> findByProjectNameContaining(String project_name, Pageable pageable);
+    Page<Project> findByContentContaining(String content, Pageable pageable);
 }

--- a/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
@@ -40,7 +40,13 @@ public class ProjectService {
     }
 
     public List<GetProjectResponse> getProjectByName(String projectName, Pageable pageable) {
+
         Page<Project> projects = projectRepository.findByProjectNameContaining(projectName, pageable);
+        return mapper.toDtoList(projects).getContent();
+    }
+
+    public List<GetProjectResponse> getProjectByContent(String content, Pageable pageable) {
+        Page<Project> projects = projectRepository.findByContentContaining(content, pageable);
         return mapper.toDtoList(projects).getContent();
     }
 


### PR DESCRIPTION
## 🛠️ 변경사항
- BaseEntity에서 자동으로 들어가야 할 값이 들어가지 않고 있어, BackendApplication 파일에 @EnableJpaAuditing 추가
- ProjectController의 getProjects 메소드에 @RequestParam으로 content를 추가해 content의 값을 통한 검색 기능 구현
</br>
</br>

## ☝️ 유의사항
- 이슈에도 따로 오류 보고를 해놨지만, request parameter가 한글이면 작동하지 않습니다
</br>
</br>

## 👀 참고자료
추후에 참고하면 좋을 것 같습니다
https://github.com/Raouf25/Spring-Boot-efficient-search-API
</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
