### PR TITLE
BE/#31 프로젝트 생성, 내용 검색 TEST 코드 추가

### DIFF
--- a/backend/src/test/java/com/graphy/backend/domain/project/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/project/controller/ProjectControllerTest.java
@@ -2,20 +2,24 @@ package com.graphy.backend.domain.project.controller;
 
 import com.graphy.backend.domain.project.domain.Project;
 import com.graphy.backend.domain.project.domain.ProjectTags;
-
+import com.graphy.backend.domain.project.dto.ProjectDto;
 import com.graphy.backend.domain.project.repository.ProjectRepository;
 import com.graphy.backend.domain.project.service.ProjectService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
-import static com.graphy.backend.domain.project.dto.ProjectDto.*;
-import static org.assertj.core.api.Assertions.*;
+import static com.graphy.backend.domain.project.dto.ProjectDto.CreateProjectRequest;
+import static com.graphy.backend.domain.project.dto.ProjectDto.UpdateProjectRequest;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
@@ -64,7 +68,6 @@ class ProjectControllerTest {
                 .description("updateDesc").techTags(new ArrayList<>()).build();
 
 
-
         //when
         projectService.updateProject(savedProject.getId(), dto);
         Project findProject = projectRepository.findById(savedProject.getId()).get();
@@ -78,5 +81,47 @@ class ProjectControllerTest {
         assertThat(findProject.getProjectName()).isEqualTo(savedProject.getProjectName());
         assertThat(findProject.getContent()).isEqualTo(savedProject.getContent());
         assertThat(findProject.getDescription()).isEqualTo(savedProject.getDescription());
+    }
+
+    @Test
+    @DisplayName("프로젝트 생성 테스트")
+    @Transactional
+    void 프로젝트_생성후_조회() throws Exception {
+
+        //given
+        List<String> techTags = new ArrayList<String>(List.of("Spring boot", "React", "TypeScript"));
+
+        CreateProjectRequest createRequest = CreateProjectRequest.builder().projectName("테스트 프로젝트")
+                .content("내용").description("한 줄 소개").techTags(techTags).build();
+
+         Pageable pageable = PageRequest.of(0,1);
+
+        //when
+        projectService.createProject(createRequest);
+        ProjectDto.GetProjectResponse result = projectService.getProjectByName("테스트 프로젝트", pageable).get(0);
+
+        //then
+        assertThat(result.getProjectName()).isEqualTo(createRequest.getProjectName());
+    }
+
+    @Test
+    @DisplayName("프로젝트 내용 검색 테스트")
+    @Transactional
+    void 프로젝트_생성후_내용검색() throws Exception {
+
+        //given
+        List<String> techTags = new ArrayList<String>(List.of("Spring boot", "React", "TypeScript"));
+
+        CreateProjectRequest createRequest = CreateProjectRequest.builder().projectName("내용 검색 제목")
+                .content("고양이").description("한 줄 소개").techTags(techTags).build();
+
+        Pageable pageable = PageRequest.of(0,1);
+
+        //when
+        projectService.createProject(createRequest);
+        ProjectDto.GetProjectResponse result = projectService.getProjectByContent("고양이", pageable).get(0);
+
+        //then
+        assertThat(result.getProjectName()).isEqualTo(createRequest.getProjectName());
     }
 }

--- a/backend/src/test/java/com/graphy/backend/domain/project/controller/ProjectIntegrationTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/project/controller/ProjectIntegrationTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
-class ProjectControllerTest {
+class ProjectIntegrationTest {
     @Autowired private ProjectRepository projectRepository;
     @Autowired private ProjectService projectService;
 


### PR DESCRIPTION
## 🛠️ 변경사항
- ProejctControllerTest -> ProjectIntegrationTest로 변경
- 프로젝트_생성후_조회, 프로젝트_생성후_내용검색 테스트 메소드 추가
</br>
</br>

## ☝️ 유의사항

</br>
</br>

## 👀 참고자료

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
