### PR TITLE
BE/#42 예외처리를 위한 ErrorResponse 세팅

### DIFF
--- a/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,7 +27,7 @@ public class ProjectController {
 
     @Operation(summary = "createProject", description = "프로젝트 생성")
     @PostMapping
-    public ResponseEntity<ResultResponse> createProject(@RequestBody CreateProjectRequest dto) {
+    public ResponseEntity<ResultResponse> createProject(@Validated @RequestBody CreateProjectRequest dto) {
 
         CreateProjectResponse response = projectService.createProject(dto);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.PROJECT_CREATE_SUCCESS, response));

--- a/backend/src/main/java/com/graphy/backend/domain/project/dto/ProjectDto.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/dto/ProjectDto.java
@@ -2,6 +2,7 @@ package com.graphy.backend.domain.project.dto;
 
 import lombok.*;
 
+import javax.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -11,8 +12,14 @@ public class ProjectDto {
     @Builder
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class CreateProjectRequest {
+
+        @NotBlank(message = "project name cannot be blank")
         private String projectName;
+
+        @NotBlank(message = "content cannot be blank")
         private String content;
+
+        @NotBlank(message = "description cannot be blank")
         private String description;
         private List<String> techTags;
         private String thumbNail;

--- a/backend/src/main/java/com/graphy/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/graphy/backend/global/error/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.graphy.backend.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/** {주체}_{이유} message 는 동사 명사형으로 마무리 */
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+  // Global
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G001", "서버 오류"),
+  INPUT_INVALID_VALUE(HttpStatus.BAD_REQUEST, "G002", "잘못된 입력"),
+
+  // 예시
+  EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "U001", "테스트용 예시 에러코드"),
+  ;
+
+  private final HttpStatus status;
+  private final String errorCode;
+  private final String message;
+}

--- a/backend/src/main/java/com/graphy/backend/global/error/ErrorResponse.java
+++ b/backend/src/main/java/com/graphy/backend/global/error/ErrorResponse.java
@@ -48,7 +48,7 @@ public class ErrorResponse {
     private String value;
     private String reason;
 
-    private static List<FieldError> of(final BindingResult bindingResult) {
+    public static List<FieldError> of(final BindingResult bindingResult) {
       final List<org.springframework.validation.FieldError> fieldErrors =
           bindingResult.getFieldErrors();
       return fieldErrors.stream()

--- a/backend/src/main/java/com/graphy/backend/global/error/ErrorResponse.java
+++ b/backend/src/main/java/com/graphy/backend/global/error/ErrorResponse.java
@@ -1,0 +1,64 @@
+package com.graphy.backend.global.error;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+  private String code;
+  private String message;
+
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  private List<FieldError> errors;
+
+  private ErrorResponse(ErrorCode code, List<FieldError> fieldErrors) {
+    this.code = code.getErrorCode();
+    this.message = code.getMessage();
+    this.errors = fieldErrors;
+  }
+
+  private ErrorResponse(ErrorCode code) {
+    this.code = code.getErrorCode();
+    this.message = code.getMessage();
+    this.errors = new ArrayList<>();
+  }
+
+  public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+    return new ErrorResponse(code, FieldError.of(bindingResult));
+  }
+
+  public static ErrorResponse of(ErrorCode code) {
+    return new ErrorResponse(code);
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class FieldError {
+    private String field;
+    private String value;
+    private String reason;
+
+    private static List<FieldError> of(final BindingResult bindingResult) {
+      final List<org.springframework.validation.FieldError> fieldErrors =
+          bindingResult.getFieldErrors();
+      return fieldErrors.stream()
+          .map(
+              error ->
+                  new FieldError(
+                      error.getField(),
+                      error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                      error.getDefaultMessage()))
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/backend/src/main/java/com/graphy/backend/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/graphy/backend/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,62 @@
+package com.graphy.backend.global.error;
+
+import com.graphy.backend.global.error.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error(e.getMessage(), e);
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleRuntimeException(BusinessException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = makeErrorResponse(errorCode);
+        log.warn(e.getMessage());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e) {
+        final ErrorResponse response =
+                ErrorResponse.of(ErrorCode.INPUT_INVALID_VALUE, e.getBindingResult());
+        log.warn(e.getMessage());
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(
+            Exception e, ErrorCode errorCode, WebRequest request) {
+        log.error(e.getMessage(), e);
+        return handleExceptionInternal(e, errorCode, errorCode.getStatus(), request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(
+            Exception e, ErrorCode errorCode, HttpStatus status, WebRequest request) {
+        return super.handleExceptionInternal(
+                e, ErrorResponse.of(errorCode), HttpHeaders.EMPTY, status, request);
+    }
+
+    private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                        .message(errorCode.getMessage())
+                        .code(errorCode.getErrorCode())
+                        .build();
+    }
+}

--- a/backend/src/main/java/com/graphy/backend/global/error/exception/BusinessException.java
+++ b/backend/src/main/java/com/graphy/backend/global/error/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.graphy.backend.global.error.exception;
+
+import com.graphy.backend.global.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}


### PR DESCRIPTION
## 🛠️ 변경사항
- 응답으로 포함할 ErrorCode 정의를 위한 ErrorCode
- 응답 body에 들어갈 ErrorResponse 정의
- @RestControllerAdvice를 이용한 GlobalExceptionHandler
- RuntimeException은 이를 상속 받아 만든 BusinessException를 이용해 INTERNAL_SERVER_ERROR를 반환하도록 정의
</br>
</br>

## ☝️ 유의사항
- dto에 validation을 추가하고, 유효하지 않은 입력이면 이렇게 메시지와 함꼐 response가 생성됩니다.
![image](https://user-images.githubusercontent.com/75435113/228180850-6f2ec8e8-d0a0-40b0-97b3-ed603d5addcc.png)
- validation 예외 말고도, 따로 정의하고 싶은 예외가 있다면 global.error.exception아래에 BusinessException 만든 것처럼 추가하시고,
GlobalExceptionHandler에서 @ExceptionHandler 어노테이션 붙여서 메소드 하나 새로 정의하시면 됩니다.

</br>
</br>

## 👀 참고자료
- https://samtao.tistory.com/42
- https://mangkyu.tistory.com/204
- https://annajin.tistory.com/184
- https://cchoimin.tistory.com/entry/Valid-%EC%99%80-ControllerAdvice%EB%A1%9C-DTO-%EC%98%88%EC%99%B8%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0
</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
