### PR TITLE
BE/#69 댓글 생성 API 구현

### DIFF
--- a/backend/src/main/java/com/graphy/backend/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/comment/controller/CommentController.java
@@ -1,10 +1,21 @@
 package com.graphy.backend.domain.comment.controller;
 
+import com.graphy.backend.domain.comment.dto.CommentDto;
 import com.graphy.backend.domain.comment.service.CommentService;
+import com.graphy.backend.global.result.ResultCode;
+import com.graphy.backend.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.graphy.backend.domain.comment.dto.CommentDto.CreateCommentResponse;
 
 @Tag(name = "CommentController", description = "댓글 관련 API")
 @RestController
@@ -12,4 +23,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CommentController {
     private final CommentService commentService;
+
+    @Operation(summary = "createComment", description = "댓글 생성")
+    @PostMapping
+    public ResponseEntity<ResultResponse> createProject(@Validated @RequestBody CommentDto.CreateCommentRequest dto) {
+        CreateCommentResponse response = commentService.createComment(dto);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ResultResponse.of(ResultCode.COMMENT_CREATE_SUCCESS, response));
+    }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/comment/domain/Comment.java
+++ b/backend/src/main/java/com/graphy/backend/domain/comment/domain/Comment.java
@@ -3,23 +3,21 @@ package com.graphy.backend.domain.comment.domain;
 import com.graphy.backend.domain.project.domain.Project;
 import com.graphy.backend.global.common.BaseEntity;
 import lombok.*;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
-
-import java.util.ArrayList;
 import java.util.List;
 
 import static javax.persistence.FetchType.LAZY;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Entity
+@Builder
 public class Comment extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "comment_id")
     private Long id;
 
@@ -35,7 +33,7 @@ public class Comment extends BaseEntity {
     private Comment parent;
 
     @OneToMany(mappedBy = "parent")
-    private List<Comment> childList = new ArrayList<>();
+    private List<Comment> childList;
 
     @Builder
     public Comment(String content, Project project, Comment parent) {

--- a/backend/src/main/java/com/graphy/backend/domain/comment/dto/CommentDto.java
+++ b/backend/src/main/java/com/graphy/backend/domain/comment/dto/CommentDto.java
@@ -1,8 +1,10 @@
 package com.graphy.backend.domain.comment.dto;
 
 import com.graphy.backend.domain.comment.domain.Comment;
+import com.graphy.backend.domain.project.domain.Project;
 import lombok.*;
 
+import javax.validation.constraints.NotBlank;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -30,6 +32,33 @@ public class CommentDto {
         }
     }
 
+    @Getter
+    @AllArgsConstructor
+    public static class CreateCommentRequest {
+
+        @NotBlank
+        private String content;
+
+        private Long projectId;
+
+        private Long parentId;
+
+        public static Comment to(CreateCommentRequest createCommentRequest, Project project, Comment parentComment) {
+            return Comment.builder()
+                    .content(createCommentRequest.getContent())
+                    .parent(parentComment)
+                    .project(project)
+                    .build();
+        }
+    }
+
+
+    @Getter
+    @AllArgsConstructor
+    public static class CreateCommentResponse {
+        private Long commentId;
+
+    }
 
     @Getter
     @AllArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/com/graphy/backend/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/comment/service/CommentService.java
@@ -1,10 +1,38 @@
 package com.graphy.backend.domain.comment.service;
 
-import lombok.AccessLevel;
+import com.graphy.backend.domain.comment.domain.Comment;
+import com.graphy.backend.domain.comment.repository.CommentRepository;
+import com.graphy.backend.domain.project.domain.Project;
+import com.graphy.backend.domain.project.repository.ProjectRepository;
+import com.graphy.backend.global.error.ErrorCode;
+import com.graphy.backend.global.error.exception.EmptyResultException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import static com.graphy.backend.domain.comment.dto.CommentDto.CreateCommentRequest;
+import static com.graphy.backend.domain.comment.dto.CommentDto.CreateCommentResponse;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
+
+    private final CommentRepository commentRepository;
+
+    private final ProjectRepository projectRepository;
+
+    public CreateCommentResponse createComment(CreateCommentRequest dto) {
+
+        Project project = projectRepository.findById(dto.getProjectId())
+                .orElseThrow(() -> new EmptyResultException(ErrorCode.PROJECT_DELETED_OR_NOT_EXIST));
+
+        Comment parentComment = null;
+        if (dto.getParentId() != null) {
+            parentComment = commentRepository.findById(dto.getParentId())
+                    .orElseThrow(() -> new EmptyResultException(ErrorCode.COMMENT_DELETED_OR_NOT_EXIST));
+        }
+
+        Comment entity = CreateCommentRequest.to(dto, project, parentComment);
+
+        return new CreateCommentResponse(commentRepository.save(entity).getId());
+    }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/project/domain/Project.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/domain/Project.java
@@ -7,7 +7,6 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -33,7 +32,7 @@ public class Project extends BaseEntity {
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("createdAt")
-    private List<Comment> comments = new ArrayList<>();
+    private List<Comment> comments;
 
     @Column(nullable = true)
     private String description;

--- a/backend/src/main/java/com/graphy/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/graphy/backend/global/error/ErrorCode.java
@@ -12,10 +12,12 @@ public enum ErrorCode {
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G001", "서버 오류"),
   INPUT_INVALID_VALUE(HttpStatus.BAD_REQUEST, "G002", "잘못된 입력"),
 
+  // Project
   PROJECT_DELETED_OR_NOT_EXIST(HttpStatus.BAD_REQUEST, "P001", "이미 삭제되거나 존재하지 않는 프로젝트"),
 
-  // 예시
-  EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "U001", "테스트용 예시 에러코드"),
+  // Comment
+  COMMENT_DELETED_OR_NOT_EXIST(HttpStatus.BAD_REQUEST, "C001", "이미 삭제되거나 존재하지 않는 댓글"),
+
   ;
 
   private final HttpStatus status;

--- a/backend/src/main/java/com/graphy/backend/global/result/ResultCode.java
+++ b/backend/src/main/java/com/graphy/backend/global/result/ResultCode.java
@@ -16,12 +16,12 @@ public enum ResultCode {
     PROJECT_GET_SUCCESS("P002", "프로젝트 조회 성공"),
     PROJECT_DELETE_SUCCESS("P003", "프로젝트 삭제 성공"),
     PROJECT_UPDATE_SUCCESS("P004", "프로젝트 수정 성공"),
-    PROJECT_PAGING_GET_SUCCESS("P005", "프로젝트 페이징 조회 성공");
-
-    // project_image
+    PROJECT_PAGING_GET_SUCCESS("P005", "프로젝트 페이징 조회 성공"),
 
     // comment
+    COMMENT_CREATE_SUCCESS("C001", "댓글 생성 성공"),
 
+    ;
 
     private final String code;
     private final String message;

--- a/backend/src/test/java/com/graphy/backend/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class CommentServiceTest {
+  
+}

--- a/backend/src/test/java/com/graphy/backend/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/comment/service/CommentServiceTest.java
@@ -1,4 +1,54 @@
-import static org.junit.jupiter.api.Assertions.*;
+package com.graphy.backend.domain.comment.service;
+
+import com.graphy.backend.domain.comment.domain.Comment;
+import com.graphy.backend.domain.comment.repository.CommentRepository;
+import com.graphy.backend.domain.project.domain.Project;
+import com.graphy.backend.domain.project.repository.ProjectRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.graphy.backend.domain.comment.dto.CommentDto.CreateCommentRequest;
+import static com.graphy.backend.domain.comment.dto.CommentDto.CreateCommentResponse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
-  
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @Mock
+    private CommentRepository commentRepository;
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Test
+    void 댓글이_생성된다() {
+
+        //given
+        CreateCommentRequest dto = new CreateCommentRequest("내용", 1L, null);
+        Project project = Project.builder().id(1L).content("테스트 프로젝트").description("테스트 프로젝트 한 줄 소개").projectName("테스트").build();
+        Comment comment = Comment.builder().id(1L).content("내용").project(project).parent(null).build();
+
+        // mocking
+        given(commentRepository.save(any()))
+                .willReturn(comment);
+        given(projectRepository.findById(1L))
+                .willReturn(Optional.ofNullable(project));
+        given(commentRepository.findById(1L))
+                .willReturn(Optional.ofNullable(comment));
+
+        //when
+        CreateCommentResponse response = commentService.createComment(dto);
+
+        //then
+        Comment findComment = commentRepository.findById(response.getCommentId()).get();
+        assertEquals(dto.getContent(), findComment.getContent());
+    }
 }

--- a/backend/src/test/java/com/graphy/backend/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/comment/service/CommentServiceTest.java
@@ -51,4 +51,36 @@ class CommentServiceTest {
         Comment findComment = commentRepository.findById(response.getCommentId()).get();
         assertEquals(dto.getContent(), findComment.getContent());
     }
+
+    @Test
+    void 대댓글이_생성된다() {
+
+        //given
+        CreateCommentRequest dto = new CreateCommentRequest("내용", 1L, 1L);
+        Project project = Project.builder().id(1L).content("테스트 프로젝트").description("테스트 프로젝트 한 줄 소개").projectName("테스트").build();
+
+        Comment parentComment = Comment.builder().id(1L).content("내용").project(project).parent(null).build();
+        Comment comment = Comment.builder().id(2L).content("내용").project(project).parent(parentComment).build();
+
+        // mocking
+
+        given(commentRepository.save(any()))
+                .willReturn(comment);
+
+        given(projectRepository.findById(1L))
+                .willReturn(Optional.of(project));
+        given(commentRepository.findById(1L))
+                .willReturn(Optional.of(parentComment));
+        given(commentRepository.findById(2L))
+                .willReturn(Optional.of(comment));
+
+
+        //when
+        CreateCommentResponse response = commentService.createComment(dto);
+
+        //then
+        Comment findComment = commentRepository.findById(response.getCommentId()).get();
+        assertEquals(parentComment, findComment.getParent());
+        assertEquals(dto.getContent(), findComment.getContent());
+    }
 }


### PR DESCRIPTION
## 🛠️ 변경사항
- 댓글 생성 API 구현
- 댓글 생성, 대댓글 생성 기능 Service 단위 테스트 추가
</br>
</br>

## ☝️ 유의사항
- @Mock과 @InjectMocks을 사용하여 테스트 코드 작성했습니다!
</br>
</br>

## 👀 참고자료
- https://galid1.tistory.com/772
- https://jiminidaddy.github.io/dev/2021/05/20/dev-spring-%EB%8B%A8%EC%9C%84%ED%85%8C%EC%8A%A4%ED%8A%B8-Repository/
</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
