### PR TITLE
BE : 댓글 삭제 API 구현 + 댓글 삭제, 조회 API 테스트 코드 작성

### DIFF
--- a/backend/src/main/java/com/graphy/backend/BackendApplication.java
+++ b/backend/src/main/java/com/graphy/backend/BackendApplication.java
@@ -4,9 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/backend/src/main/java/com/graphy/backend/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/comment/controller/CommentController.java
@@ -10,10 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.graphy.backend.domain.comment.dto.CommentDto.CreateCommentResponse;
 
@@ -31,5 +28,13 @@ public class CommentController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ResultResponse.of(ResultCode.COMMENT_CREATE_SUCCESS, response));
+    }
+
+    @Operation(summary = "deleteComment", description = "댓글 삭제")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ResultResponse> deleteComment(@PathVariable Long id) {
+        commentService.deleteComment(id);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ResultResponse.of(ResultCode.COMMENT_DELETE_SUCCESS));
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/comment/domain/Comment.java
+++ b/backend/src/main/java/com/graphy/backend/domain/comment/domain/Comment.java
@@ -3,6 +3,8 @@ package com.graphy.backend.domain.comment.domain;
 import com.graphy.backend.domain.project.domain.Project;
 import com.graphy.backend.global.common.BaseEntity;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.util.List;
@@ -14,6 +16,8 @@ import static javax.persistence.FetchType.LAZY;
 @AllArgsConstructor
 @Entity
 @Builder
+@SQLDelete(sql = "UPDATE comment SET is_deleted = true WHERE comment_id = ?")
+@Where(clause = "is_deleted = false")
 public class Comment extends BaseEntity {
 
     @Id
@@ -40,5 +44,9 @@ public class Comment extends BaseEntity {
         this.content = content;
         this.project = project;
         this.parent = parent;
+    }
+
+    public void deleteComment(Comment comment) {
+        comment.content = "삭제된 댓글입니다.";
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/comment/dto/CommentDto.java
+++ b/backend/src/main/java/com/graphy/backend/domain/comment/dto/CommentDto.java
@@ -5,6 +5,7 @@ import com.graphy.backend.domain.project.domain.Project;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,6 +18,7 @@ public class CommentDto {
         private Long commentId;
         private String content;
         private List<ChildComments> childComments;
+        private LocalDateTime createdAt;
 
         public static GetCommentsResponse from(Comment comment) {
             List<ChildComments> childCommentsList = comment.getChildList()
@@ -27,7 +29,8 @@ public class CommentDto {
                     comment.getProject().getId(),
                     comment.getId(),
                     comment.getContent(),
-                    childCommentsList
+                    childCommentsList,
+                    comment.getCreatedAt()
             );
         }
     }
@@ -66,10 +69,14 @@ public class CommentDto {
         private Long parentId;
         private Long commentId;
         private String content;
+        private LocalDateTime createdAt;
 
         public static ChildComments from(Comment childComment) {
-            return new ChildComments(childComment.getParent().getId(),
-                    childComment.getId(), childComment.getContent());
+            return new ChildComments(
+                    childComment.getParent().getId(),
+                    childComment.getId(),
+                    childComment.getContent(),
+                    childComment.getCreatedAt());
         }
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/comment/service/CommentService.java
@@ -9,6 +9,8 @@ import com.graphy.backend.global.error.exception.EmptyResultException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
+
 import static com.graphy.backend.domain.comment.dto.CommentDto.CreateCommentRequest;
 import static com.graphy.backend.domain.comment.dto.CommentDto.CreateCommentResponse;
 
@@ -34,5 +36,36 @@ public class CommentService {
         Comment entity = CreateCommentRequest.to(dto, project, parentComment);
 
         return new CreateCommentResponse(commentRepository.save(entity).getId());
+    }
+
+    @Transactional
+    public void deleteComment(Long id) {
+        Comment comment = commentRepository.findById(id)
+                .orElseThrow(() -> new EmptyResultException(ErrorCode.PROJECT_DELETED_OR_NOT_EXIST));
+
+        // 대댓글인 경우
+        if (comment.getParent() != null) {
+            // 삭제
+            comment.setDeletedTrue();
+            //commentRepository.delete(comment);
+
+            //부모 댓글이 삭제된 상태고 다른 대댓글이 없으면 부모 댓글도 삭제
+            if (comment.getParent().getContent().equals("삭제된 댓글입니다.") &&
+                    comment.getParent().getChildList().size() == 1) {
+                comment.getParent().setDeletedTrue();
+//                commentRepository.delete(comment.getParent());
+            }
+
+            // 부모 댓글인 경우
+        } else {
+
+            // 자식 댓글이 없으면 삭제
+            if (comment.getChildList().isEmpty()) {
+                comment.setDeletedTrue();
+//                commentRepository.delete(comment);
+            }
+            // 자식 댓글이 남았으면 "삭제된 댓글입니다."
+            comment.deleteComment(comment);
+        }
     }
 }

--- a/backend/src/main/java/com/graphy/backend/global/common/BaseEntity.java
+++ b/backend/src/main/java/com/graphy/backend/global/common/BaseEntity.java
@@ -31,4 +31,8 @@ public abstract class BaseEntity {
     private LocalDateTime updatedAt;
 
     private boolean isDeleted;
+
+    public void setDeletedTrue() {
+        this.isDeleted = true;
+    }
 }

--- a/backend/src/main/java/com/graphy/backend/global/common/BaseEntity.java
+++ b/backend/src/main/java/com/graphy/backend/global/common/BaseEntity.java
@@ -32,7 +32,7 @@ public abstract class BaseEntity {
 
     private boolean isDeleted;
 
-    public void setDeletedTrue() {
+    public void delete() {
         this.isDeleted = true;
     }
 }

--- a/backend/src/main/java/com/graphy/backend/global/config/JpaAuditingConfiguration.java
+++ b/backend/src/main/java/com/graphy/backend/global/config/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.graphy.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/backend/src/main/java/com/graphy/backend/global/result/ResultCode.java
+++ b/backend/src/main/java/com/graphy/backend/global/result/ResultCode.java
@@ -20,6 +20,7 @@ public enum ResultCode {
 
     // comment
     COMMENT_CREATE_SUCCESS("C001", "댓글 생성 성공"),
+    COMMENT_DELETE_SUCCESS("C002", "댓글 삭제 성공"),
 
     ;
 

--- a/backend/src/test/java/com/graphy/backend/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/comment/service/CommentServiceTest.java
@@ -10,11 +10,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 import static com.graphy.backend.domain.comment.dto.CommentDto.CreateCommentRequest;
 import static com.graphy.backend.domain.comment.dto.CommentDto.CreateCommentResponse;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -82,5 +83,83 @@ class CommentServiceTest {
         Comment findComment = commentRepository.findById(response.getCommentId()).get();
         assertEquals(parentComment, findComment.getParent());
         assertEquals(dto.getContent(), findComment.getContent());
+    }
+
+    @Test
+    public void 대댓글의_경우_바로_삭제() throws Exception {
+        //given
+        Comment comment = Comment.builder().id(1L).content("댓글").build();
+        Comment reComment = Comment.builder().id(2L).content("대댓글1").parent(comment).build();
+
+        // mocking
+        given(commentRepository.findById(2L)).willReturn(Optional.of(reComment));
+
+        // when
+        commentService.deleteComment(2L);
+
+        //then
+        assertTrue(reComment.isDeleted());
+    }
+
+    @Test
+    public void 대댓글_삭제_후에_부모댓글이_삭제된_상태고_대댓글이_없으면_부모댓글도_삭제() throws Exception {
+
+        //given
+        Comment comment = Comment.builder().id(1L).content("삭제된 댓글입니다.").childList(new ArrayList<>()).build();
+        Comment reComment = Comment.builder().id(2L).content("대댓글").parent(comment).build();
+        comment.getChildList().add(reComment);
+
+        //mocking
+        given(commentRepository.findById(2L)).willReturn(Optional.of(reComment));
+
+        // when
+        commentService.deleteComment(2L);
+
+        //then
+        assertTrue(comment.isDeleted());
+        assertTrue(reComment.isDeleted());
+    }
+
+    @Test
+    public void 댓글의_경우_대댓글이_남았으면_삭제된_댓글입니다_표시() throws Exception {
+
+        //given
+        Comment comment = Comment.builder().id(2L).content("댓글").childList(new ArrayList<>()).build();
+
+        Comment reComment1 = Comment.builder().content("대댓글1").build();
+        Comment reComment2 = Comment.builder().content("대댓글2").build();
+
+        comment.getChildList().add(reComment1);
+        comment.getChildList().add(reComment2);
+
+        // mocking
+        given(commentRepository.findById(2L)).willReturn(Optional.of(comment));
+
+        //when
+        System.out.println("============삭제 전============");
+        System.out.println(comment.getContent()+"\n");
+        commentService.deleteComment(2L);
+
+        //then
+        System.out.println("============삭제 후============");
+        System.out.println(comment.getContent());
+        assertEquals(comment.getContent(), "삭제된 댓글입니다.");
+    }
+
+    @Test
+    public void 댓글의_경우_대댓글이_없으면_삭제() throws Exception {
+
+        //given
+
+        Comment comment = Comment.builder().id(2L).content("댓글").childList(new ArrayList<>()).build();
+
+        //mocking
+        given(commentRepository.findById(2L)).willReturn(Optional.ofNullable(comment));
+
+        // when
+        commentService.deleteComment(2L);
+
+        // then
+        assertTrue(comment.isDeleted());
     }
 }

--- a/backend/src/test/java/com/graphy/backend/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/comment/service/CommentServiceTest.java
@@ -4,6 +4,7 @@ import com.graphy.backend.domain.comment.domain.Comment;
 import com.graphy.backend.domain.comment.repository.CommentRepository;
 import com.graphy.backend.domain.project.domain.Project;
 import com.graphy.backend.domain.project.repository.ProjectRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -147,7 +148,8 @@ class CommentServiceTest {
     }
 
     @Test
-    public void 댓글의_경우_대댓글이_없으면_삭제() throws Exception {
+    @DisplayName("댓글의 경우 대댓글이 없으면 삭제")
+    public void deleteCommentWithoutReComment() throws Exception {
 
         //given
 
@@ -155,6 +157,7 @@ class CommentServiceTest {
 
         //mocking
         given(commentRepository.findById(2L)).willReturn(Optional.ofNullable(comment));
+
 
         // when
         commentService.deleteComment(2L);

--- a/backend/src/test/java/com/graphy/backend/domain/project/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/project/controller/ProjectControllerTest.java
@@ -45,8 +45,8 @@ public class ProjectControllerTest {
     @Test
     public void 댓글과_대댓글이_조회된다() throws Exception {
         //given
-        GetCommentsResponse getCommentsResponse1 = new GetCommentsResponse(1L, 3L, "content", null);
-        GetCommentsResponse getCommentsResponse2 = new GetCommentsResponse(1L, 4L, "content2", null);
+        GetCommentsResponse getCommentsResponse1 = new GetCommentsResponse(1L, 3L, "content", null, null);
+        GetCommentsResponse getCommentsResponse2 = new GetCommentsResponse(1L, 4L, "content2", null, null);
 
         List<GetCommentsResponse> list = new ArrayList<>();
         list.add(getCommentsResponse1);

--- a/backend/src/test/java/com/graphy/backend/domain/project/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/project/controller/ProjectControllerTest.java
@@ -1,0 +1,66 @@
+package com.graphy.backend.domain.project.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.graphy.backend.domain.comment.domain.Comment;
+import com.graphy.backend.domain.comment.dto.CommentDto;
+import com.graphy.backend.domain.comment.service.CommentService;
+import com.graphy.backend.domain.project.domain.Project;
+import com.graphy.backend.domain.project.dto.ProjectDto;
+import com.graphy.backend.domain.project.service.ProjectService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.graphy.backend.domain.comment.dto.CommentDto.*;
+import static com.graphy.backend.domain.project.dto.ProjectDto.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProjectController.class)
+@ExtendWith(MockitoExtension.class)
+public class ProjectControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    ProjectService projectService;
+
+    @MockBean
+    CommentService commentService;
+
+    private static String baseUrl = "/api/v1/projects";
+
+
+
+    @Test
+    public void 댓글과_대댓글이_조회된다() throws Exception {
+        //given
+        GetCommentsResponse getCommentsResponse1 = new GetCommentsResponse(1L, 3L, "content", null);
+        GetCommentsResponse getCommentsResponse2 = new GetCommentsResponse(1L, 4L, "content2", null);
+
+        List<GetCommentsResponse> list = new ArrayList<>();
+        list.add(getCommentsResponse1);
+        list.add(getCommentsResponse2);
+
+        GetProjectDetailResponse build = GetProjectDetailResponse.builder().projectName("name")
+                .id(2L).commentsList(list).build();
+
+        given(projectService.getProjectById(1L)).willReturn(build);
+
+
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get(baseUrl + "/{projectId}", 1L))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/com/graphy/backend/domain/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/project/service/ProjectServiceTest.java
@@ -1,0 +1,60 @@
+package com.graphy.backend.domain.project.service;
+
+import com.graphy.backend.domain.comment.domain.Comment;
+import com.graphy.backend.domain.comment.dto.CommentDto;
+import com.graphy.backend.domain.comment.repository.CommentRepository;
+import com.graphy.backend.domain.comment.service.CommentService;
+import com.graphy.backend.domain.project.domain.Project;
+import com.graphy.backend.domain.project.dto.ProjectDto;
+import com.graphy.backend.domain.project.repository.ProjectRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.graphy.backend.domain.project.dto.ProjectDto.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class ProjectServiceTest {
+
+    @InjectMocks
+    private ProjectService projectService;
+
+    @Mock
+    private CommentRepository commentRepository;
+    @Mock
+    private ProjectRepository projectRepository;
+    @Mock
+    private CommentService commentService;
+
+
+//    @Test
+//    public void 댓글과_대댓글이_조회된다() throws Exception {
+//        //given
+//        Project project = Project.builder().id(1L).content("project content").description("project dec").projectName("project").build();
+//
+//        Comment parentComment = Comment.builder().content("1번 댓글").project(project).build();
+//        Comment childComment = Comment.builder().content("1번 댓글의 답글").project(project).parent(parentComment).build();
+//        CommentDto.CreateCommentRequest dto = new CommentDto.CreateCommentRequest("1번 댓글", 1L, 1L);
+//
+//
+//        given(commentRepository.save(any())).willReturn(parentComment);
+//        given(projectRepository.findById(project.getId())).willReturn(Optional.of(project));
+//        given(commentRepository.findById(parentComment.getId())).willReturn(Optional.of(parentComment));
+//        given(commentRepository.findById(childComment.getId())).willReturn(Optional.of(childComment));
+//
+//        //when
+//        GetProjectDetailResponse response = projectService.getProjectById(project.getId());
+//        commentService.createComment(dto);
+//
+//        //then
+//        assertTrue(response.getCommentsList().contains());
+//    }
+
+}


### PR DESCRIPTION
## 🛠️ 변경사항
- 댓글 삭제 API 구현했습니다.
- 댓글 삭제, 조회 API 테스트 코드 작성했습니다.

</br>
</br>

## ☝️ 유의사항
**댓글 삭제 API 로직입니다!**
![image](https://user-images.githubusercontent.com/96862049/232308072-e202e7c4-b0c9-4425-a6c6-9c43ccebce75.png)


</br>
</br>

## 👀 참고자료

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
