### PR TITLE
BE/#76 SonarQube 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ backend/src/test/resources/application-test.yml
 backend/src/main/resources/application-local.yml
 backend/src/main/resources/application-docker.yml
 backend/src/main/resources/application-dbconfig.yml
-backend/src/main/resources/properties/sonarqube.properties
+backend/gradle.properties
+
 .idea/**

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ backend/src/test/resources/application-test.yml
 backend/src/main/resources/application-local.yml
 backend/src/main/resources/application-docker.yml
 backend/src/main/resources/application-dbconfig.yml
-
+backend/src/main/resources/properties/sonarqube.properties
 .idea/**

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11
+FROM openjdk:11-jre-slim-buster
 VOLUME /tmp
 
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -11,8 +11,6 @@ plugins {
     id 'org.sonarqube' version "3.3"
 }
 
-def sonarqubeProperties = new Properties();
-file("src/main/resources/properties/sonarqube.properties").withInputStream {{ sonarqubeProperties.load(it) }}
 
 test {
     useJUnitPlatform()
@@ -37,7 +35,7 @@ sonarqube {
         property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/jacoco/xml/jacoco.xml"
         property 'sonar.sources', 'src'
         property 'sonar.language', 'java'
-        property 'sonar.login', sonarqubeProperties.getProperty("login")
+        property 'sonar.login', '${project.login}'
     }
 }
 tasks.sonarqube.dependsOn test
@@ -72,7 +70,7 @@ dependencies {
 
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'junit:junit:4.13.1'
+    implementation 'junit:junit:4.13.2'
 
     // lombok
     annotationProcessor 'org.projectlombok:lombok'
@@ -91,7 +89,7 @@ dependencies {
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
     //swagger
-    implementation 'org.springdoc:springdoc-openapi-ui:1.6.8'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 
 }
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,11 +1,46 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '2.7.9'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 
     // rest-docs
     id 'org.asciidoctor.jvm.convert' version "3.3.2"
+
+    // sonarqube
+    id 'org.sonarqube' version "3.3"
 }
+
+def sonarqubeProperties = new Properties();
+file("src/main/resources/properties/sonarqube.properties").withInputStream {{ sonarqubeProperties.load(it) }}
+
+test {
+    useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled true
+        csv.enabled false
+        xml.destination file("${buildDir}/jacoco/xml/jacoco.xml")
+        html.destination file("${buildDir}/jacoco/html")
+    }
+    dependsOn test
+}
+
+sonarqube {
+    properties {
+        property "sonar.sourceEncoding", "UTF-8"
+        property "sonar.exclusions", "src/test/java/**"
+        property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/jacoco/xml/jacoco.xml"
+        property 'sonar.sources', 'src'
+        property 'sonar.language', 'java'
+        property 'sonar.login', sonarqubeProperties.getProperty("login")
+    }
+}
+tasks.sonarqube.dependsOn test
 
 group = 'com.graphy'
 version = '0.0.1-SNAPSHOT'
@@ -19,6 +54,7 @@ configurations {
     // rest-docs
     asciidoctorExtensions
 }
+
 
 repositories {
     mavenCentral()
@@ -58,6 +94,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.8'
 
 }
+
 
 tasks.named('test') {
     outputs.dir snippetsDir


### PR DESCRIPTION
## 🛠️ 변경사항
- build.gradle에 sonarqube 관련 세팅 추가
- sonarqube login 정보 관리를 위한 sonarqube.properties 추가 (.gitignore에 포함)
- Backend Docker 이미지 변경도 반영
</br>
</br>

## ☝️ 유의사항
- 현재 sonarqube를 docker container로 실행 후에 localhost:9000으로 sonarqube 진입 가능합니다.
</br>
</br>

## 👀 참고자료

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
