### PR TITLE
BE/#104 chatGPT 연결 및 기능 구현

### DIFF
--- a/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
@@ -18,6 +18,8 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import static com.graphy.backend.domain.project.dto.ProjectDto.*;
 
@@ -77,8 +79,12 @@ public class ProjectController {
 
     @Operation(summary = "getProjectPlan", description = "프로젝트 고도화 계획 제안")
     @PostMapping("/plans")
-    public ResponseEntity<ResultResponse> createPlan(final @RequestBody GetPlanRequest getPlanRequest) {
-        GptCompletionDto.GptCompletionResponse response = projectService.getProjectPlan(getPlanRequest);
+    public ResponseEntity<ResultResponse> createPlan(final @RequestBody GetPlanRequest getPlanRequest) throws ExecutionException, InterruptedException {
+        CompletableFuture<GptCompletionDto.GptCompletionResponse> futureResult =
+                projectService.getProjectPlanAsync(getPlanRequest).thenApply(result -> {
+                    return result;
+                });
+        GptCompletionDto.GptCompletionResponse response = futureResult.get();
         return ResponseEntity.ok(ResultResponse.of(ResultCode.PLAN_CREATE_SUCCESS, response));
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
@@ -59,7 +59,7 @@ public class ProjectController {
             "\t\t2. 오름차순이 기본입니다. 내림차순을 원하실 경우 {정렬기준},desc (ex. \"id,desc\")를 입력해주세요 (콤마 사이 띄어쓰기 X)\n\n" +
             "\t\t3. sort의 default(공백 입력) : createdAt(최신순), 내림차순")
 
-    @PostMapping("/search")
+    @GetMapping("/search")
     public ResponseEntity<ResultResponse> getProjects(GetProjectsRequest dto, PageRequest pageRequest) {
         Pageable pageable = pageRequest.of();
         List<GetProjectResponse> result = projectService.getProjects(dto, pageable);

--- a/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
@@ -80,8 +80,12 @@ public class ProjectController {
     @Operation(summary = "getProjectPlan", description = "프로젝트 고도화 계획 제안")
     @PostMapping("/plans")
     public ResponseEntity<ResultResponse> createPlan(final @RequestBody GetPlanRequest getPlanRequest) throws ExecutionException, InterruptedException {
+        String prompt = projectService.getPrompt(getPlanRequest);
+        projectService.checkGptRequestToken(prompt);
+
+
         CompletableFuture<GptCompletionDto.GptCompletionResponse> futureResult =
-                projectService.getProjectPlanAsync(getPlanRequest).thenApply(result -> {
+                projectService.getProjectPlanAsync(prompt).thenApply(result -> {
                     return result;
                 });
         GptCompletionDto.GptCompletionResponse response = futureResult.get();

--- a/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
@@ -1,8 +1,6 @@
 package com.graphy.backend.domain.project.controller;
 
 import com.graphy.backend.domain.project.service.ProjectService;
-import com.graphy.backend.global.chatgpt.dto.GptCompletionDto;
-import com.graphy.backend.global.chatgpt.service.GPTChatRestService;
 import com.graphy.backend.global.common.PageRequest;
 import com.graphy.backend.global.error.ErrorCode;
 import com.graphy.backend.global.error.exception.EmptyResultException;
@@ -29,7 +27,6 @@ import static com.graphy.backend.domain.project.dto.ProjectDto.*;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProjectController {
     private final ProjectService projectService;
-    private final GPTChatRestService gptChatRestService;
 
     @Operation(summary = "createProject", description = "프로젝트 생성")
     @PostMapping
@@ -83,12 +80,12 @@ public class ProjectController {
         String prompt = projectService.getPrompt(getPlanRequest);
         projectService.checkGptRequestToken(prompt);
 
-
-        CompletableFuture<GptCompletionDto.GptCompletionResponse> futureResult =
+        CompletableFuture<String> futureResult =
                 projectService.getProjectPlanAsync(prompt).thenApply(result -> {
                     return result;
                 });
-        GptCompletionDto.GptCompletionResponse response = futureResult.get();
+        String response = futureResult.get();
+
         return ResponseEntity.ok(ResultResponse.of(ResultCode.PLAN_CREATE_SUCCESS, response));
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
@@ -77,8 +77,8 @@ public class ProjectController {
 
     @Operation(summary = "getProjectPlan", description = "프로젝트 고도화 계획 제안")
     @PostMapping("/plans")
-    public ResponseEntity<ResultResponse> createPlan(final @RequestBody GptCompletionDto.GptCompletionRequest gptCompletionRequest) {
-        GptCompletionDto.GptCompletionResponse response = gptChatRestService.completion(gptCompletionRequest);
+    public ResponseEntity<ResultResponse> createPlan(final @RequestBody GetPlanRequest getPlanRequest) {
+        GptCompletionDto.GptCompletionResponse response = projectService.getProjectPlan(getPlanRequest);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.PLAN_CREATE_SUCCESS, response));
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/project/dto/ProjectDto.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/dto/ProjectDto.java
@@ -61,13 +61,13 @@ public class ProjectDto {
         @NotBlank(message = "topic cannot be blank")
         private String topic;
 
-        @Size(min=1, max=10, message = "features are not the right number.")
+        @Size(min=1, max=5, message = "features are not the right number.")
         private List<String> features;
 
         @Size(min=1, max=15, message = "techStacks are not the right number.")
         private List<String> techStacks;
 
-        @Size(min=1, max=10, message = "plans are not the right number.")
+        @Size(min=1, max=5, message = "plans are not the right number.")
         private List<String> plans;
     }
 

--- a/backend/src/main/java/com/graphy/backend/domain/project/dto/ProjectDto.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/dto/ProjectDto.java
@@ -4,6 +4,7 @@ import com.graphy.backend.domain.comment.dto.CommentWithMaskingDto;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -14,6 +15,7 @@ public class ProjectDto {
     @Builder
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class CreateProjectRequest {
+
 
         @NotBlank(message = "project name cannot be blank")
         private String projectName;
@@ -37,7 +39,6 @@ public class ProjectDto {
         private String content;
     }
 
-
     @Getter
     @Builder
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -50,6 +51,24 @@ public class ProjectDto {
         private String description;
         private List<String> techTags;
         private String thumbNail;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetPlanRequest {
+        @NotBlank(message = "topic cannot be blank")
+        private String topic;
+
+        @Size(min=1, max=10, message = "features are not the right number.")
+        private List<String> features;
+
+        @Size(min=1, max=15, message = "techStacks are not the right number.")
+        private List<String> techStacks;
+
+        @Size(min=1, max=10, message = "plans are not the right number.")
+        private List<String> plans;
     }
 
     @Getter

--- a/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
@@ -117,11 +117,13 @@ public class ProjectService {
 
     public GptCompletionDto.GptCompletionResponse getProjectPlan(final GetPlanRequest request) {
         GptCompletionDto.GptCompletionRequest dto = new GptCompletionDto.GptCompletionRequest();
+
         String techStacks = String.join(", ", request.getTechStacks());
         String plans = String.join(", ", request.getPlans());
         String features = String.join(", ", request.getFeatures());
         String prompt = techStacks + "를 이용해" + request.getTopic() +"를 개발 중이고, 현재"
                 + features + "까지 기능 구현한 상태에서 고도화된 기능과 " + plans + "을 사용한 고도화 방안을 알려줘";
+
         dto.setPrompt(prompt);
         return gptChatRestService.completion(dto);
     }

--- a/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
@@ -136,7 +136,9 @@ public class ProjectService {
         System.out.println("비동기 작업 시작");
         GptCompletionResponse result = gptChatRestService.completion(request);
         System.out.println("비동기 작업 완료");
-        callback.accept(result.getMessages().get(0).getText());
+        String response = result.getMessages().get(0).getText()
+                .replace("\n", " ").replace("\n\n", " ");
+        callback.accept(response);
     }
 
     public void checkGptRequestToken(String prompt) {

--- a/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
@@ -9,6 +9,8 @@ import com.graphy.backend.domain.project.mapper.ProjectMapper;
 import com.graphy.backend.domain.project.repository.ProjectRepository;
 import com.graphy.backend.domain.project.repository.ProjectTagRepository;
 import com.graphy.backend.domain.project.repository.TagRepository;
+import com.graphy.backend.global.chatgpt.dto.GptCompletionDto;
+import com.graphy.backend.global.chatgpt.service.GPTChatRestService;
 import com.graphy.backend.global.error.ErrorCode;
 import com.graphy.backend.global.error.exception.EmptyResultException;
 import lombok.AccessLevel;
@@ -39,6 +41,7 @@ public class ProjectService {
     private final ProjectMapper mapper;
     private final CommentRepository commentRepository;
 
+    private final GPTChatRestService gptChatRestService;
 
     @PostConstruct
     public void initTag() throws IOException {
@@ -110,5 +113,16 @@ public class ProjectService {
     public List<GetProjectResponse> getProjects(GetProjectsRequest dto, Pageable pageable) {
         Page<Project> projects = projectRepository.searchProjectsWith(pageable, dto.getProjectName(), dto.getContent());
         return mapper.toDtoList(projects).getContent();
+    }
+
+    public GptCompletionDto.GptCompletionResponse getProjectPlan(final GetPlanRequest request) {
+        GptCompletionDto.GptCompletionRequest dto = new GptCompletionDto.GptCompletionRequest();
+        String techStacks = String.join(", ", request.getTechStacks());
+        String plans = String.join(", ", request.getPlans());
+        String features = String.join(", ", request.getFeatures());
+        String prompt = techStacks + "를 이용해" + request.getTopic() +"를 개발 중이고, 현재"
+                + features + "까지 기능 구현한 상태에서 고도화된 기능과 " + plans + "을 사용한 고도화 방안을 알려줘";
+        dto.setPrompt(prompt);
+        return gptChatRestService.completion(dto);
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
@@ -123,20 +123,20 @@ public class ProjectService {
     }
 
     @Async
-    public CompletableFuture<GptCompletionResponse> getProjectPlanAsync(String prompt) {
+    public CompletableFuture<String> getProjectPlanAsync(String prompt) {
         GptCompletionRequest dto = new GptCompletionDto.GptCompletionRequest();
-        CompletableFuture<GptCompletionResponse> response = new CompletableFuture<>();
+        CompletableFuture<String> response = new CompletableFuture<>();
 
         dto.setPrompt(prompt);
         GptApiCall(dto, response::complete);
         return response;
     }
 
-    private void GptApiCall(GptCompletionRequest request, Consumer<GptCompletionResponse> callback) {
+    private void GptApiCall(GptCompletionRequest request, Consumer<String> callback) {
         System.out.println("비동기 작업 시작");
         GptCompletionResponse result = gptChatRestService.completion(request);
         System.out.println("비동기 작업 완료");
-        callback.accept(result);
+        callback.accept(result.getMessages().get(0).getText());
     }
 
     public void checkGptRequestToken(String prompt) {

--- a/backend/src/main/java/com/graphy/backend/global/chatgpt/dto/GptCompletionDto.java
+++ b/backend/src/main/java/com/graphy/backend/global/chatgpt/dto/GptCompletionDto.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.graphy.backend.global.config.ChatGPTConfig.*;
+
 public class GptCompletionDto {
 
     @Getter
@@ -17,9 +19,9 @@ public class GptCompletionDto {
     @AllArgsConstructor
     public static class GptCompletionRequest {
 
-        private String model = "text-davinci-003";
+        private String model = MODEL_NAME;
         private String prompt;
-        private Integer maxToken = 3500;
+        private Integer maxToken = MAX_TOKEN;
 
         public static CompletionRequest of(GptCompletionRequest restRequest) {
             return CompletionRequest.builder()

--- a/backend/src/main/java/com/graphy/backend/global/chatgpt/dto/GptCompletionDto.java
+++ b/backend/src/main/java/com/graphy/backend/global/chatgpt/dto/GptCompletionDto.java
@@ -17,9 +17,9 @@ public class GptCompletionDto {
     @AllArgsConstructor
     public static class GptCompletionRequest {
 
-        private String model;
+        private String model = "text-davinci-003";
         private String prompt;
-        private Integer maxToken;
+        private Integer maxToken = 3500;
 
         public static CompletionRequest of(GptCompletionRequest restRequest) {
             return CompletionRequest.builder()
@@ -27,6 +27,10 @@ public class GptCompletionDto {
                     .prompt(restRequest.getPrompt())
                     .maxTokens(restRequest.getMaxToken())
                     .build();
+        }
+
+        public void setPrompt(String prompt) {
+            this.prompt = prompt;
         }
     }
 

--- a/backend/src/main/java/com/graphy/backend/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/graphy/backend/global/config/AsyncConfig.java
@@ -1,0 +1,22 @@
+package com.graphy.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    @Bean
+    public ThreadPoolTaskExecutor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(30);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("LSH-ASYNC-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/backend/src/main/java/com/graphy/backend/global/config/ChatGPTConfig.java
+++ b/backend/src/main/java/com/graphy/backend/global/config/ChatGPTConfig.java
@@ -15,6 +15,9 @@ public class ChatGPTConfig {
     @Value("${gpt.token}")
     private String token;
 
+    public static final String MODEL_NAME = "text-davinci-003";
+    public static final int MAX_TOKEN = 3500;
+
     @Bean
     public OpenAiService openAiService() {
         return new OpenAiService(token, Duration.ofSeconds(120));

--- a/backend/src/main/java/com/graphy/backend/global/config/ChatGPTConfig.java
+++ b/backend/src/main/java/com/graphy/backend/global/config/ChatGPTConfig.java
@@ -16,8 +16,9 @@ public class ChatGPTConfig {
     private String token;
 
     public static final String MODEL_NAME = "text-davinci-003";
-    public static final int MAX_TOKEN = 3500;
+    public static final int MAX_TOKEN = 2100;
 
+    public static final int MAX_REQUEST_TOKEN = 1800;
     @Bean
     public OpenAiService openAiService() {
         return new OpenAiService(token, Duration.ofSeconds(120));

--- a/backend/src/main/java/com/graphy/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/graphy/backend/global/error/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
   // Comment
   COMMENT_DELETED_OR_NOT_EXIST(HttpStatus.BAD_REQUEST, "C001", "이미 삭제되거나 존재하지 않는 댓글"),
 
+  // ChatGPT
+  REQUEST_TOO_MUCH_TOKENS(HttpStatus.BAD_REQUEST, "AI001", "GPT에 보내야 할 요청 길이 제한 초과"),
   ;
 
   private final HttpStatus status;

--- a/backend/src/main/java/com/graphy/backend/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/graphy/backend/global/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.graphy.backend.global.error;
 
 import com.graphy.backend.global.error.exception.BusinessException;
 import com.graphy.backend.global.error.exception.EmptyResultException;
+import com.graphy.backend.global.error.exception.LongRequestException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(EmptyResultException.class)
     protected ResponseEntity<ErrorResponse> handleEmptyResultException(EmptyResultException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = makeErrorResponse(errorCode);
+        log.warn(e.getMessage());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(LongRequestException.class)
+    protected ResponseEntity<ErrorResponse> handleLongRequestException(LongRequestException e) {
         final ErrorCode errorCode = e.getErrorCode();
         final ErrorResponse response = makeErrorResponse(errorCode);
         log.warn(e.getMessage());

--- a/backend/src/main/java/com/graphy/backend/global/error/exception/LongRequestException.java
+++ b/backend/src/main/java/com/graphy/backend/global/error/exception/LongRequestException.java
@@ -1,0 +1,14 @@
+package com.graphy.backend.global.error.exception;
+
+import com.graphy.backend.global.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class LongRequestException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public LongRequestException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,9 +4,9 @@ spring:
 
   mvc:
     pathmatch:
+      matching-strategy: ant_path_matcher
     async:
       request-timeout: 60000
-      matching-strategy: ant_path_matcher
   profiles:
     active: local
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,6 +4,8 @@ spring:
 
   mvc:
     pathmatch:
+    async:
+      request-timeout: 60000
       matching-strategy: ant_path_matcher
   profiles:
     active: local

--- a/backend/src/test/java/com/graphy/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/graphy/backend/BackendApplicationTests.java
@@ -1,13 +1,8 @@
 package com.graphy.backend;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class BackendApplicationTests {
-
-//    @Test
-//    void contextLoads() {
-//    }
 
 }

--- a/backend/src/test/java/com/graphy/backend/domain/project/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/project/controller/ProjectControllerTest.java
@@ -29,7 +29,6 @@ import static com.graphy.backend.domain.project.dto.ProjectDto.GetProjectDetailR
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProjectController.class)
@@ -120,7 +119,7 @@ class ProjectControllerTest extends MockApiTest {
 
         // when
         String body = objectMapper.writeValueAsString(request);
-        ResultActions resultActions = mvc.perform(post(baseUrl+"/search")
+        ResultActions resultActions = mvc.perform(get(baseUrl+"/search")
                 .param("projectName", projectName).param("pageRequest", pageRequest.toString()).contentType(MediaType.APPLICATION_JSON));
 
         // then


### PR DESCRIPTION
## 🛠️ 변경사항
- chatGPT 라이브러리 적용
- 프로젝트 고도화 계획 API 추가
- ProjectService에 getProjectPlanAsync(), GptApiCall(), checkGptRequestToken(), getPrompt() 메서드 추가
- 각각 GptAPI 비동기처리, GptAPI 호출, 요청 글자수 제한 예외처리, chatGPT에게 요청할 형식 조작 로직을 수행
- 관련 MockAPI Test 추가
</br>
</br>

## ☝️ 유의사항
- 일단 비동기처리 해놨는데, 좀 더 알아봐야 할 것 같습니다
</br>
</br>

## 👀 참고자료

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
