### PR TITLE
BE/#194 Like 도메인 리팩토링

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,4 +5,4 @@ ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait
 RUN chmod +x /wait
 
 COPY ./build/libs/backend-0.0.1-SNAPSHOT.jar app.jar
-CMD /wait && java -jar /app.jar
+CMD /wait && java -jar /app.jar --spring.profiles.active=prod

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM openjdk:11-jre-slim-buster
+VOLUME /tmp
+
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
+RUN chmod +x /wait
+
+COPY ./build/libs/backend-0.0.1-SNAPSHOT.jar app.jar
+CMD /wait && java -jar /app.jar

--- a/backend/src/main/java/com/graphy/backend/domain/auth/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/auth/service/CustomUserDetailsService.java
@@ -1,12 +1,11 @@
 package com.graphy.backend.domain.auth.service;
 
-import com.graphy.backend.domain.member.domain.Member;
 import com.graphy.backend.domain.auth.util.MemberInfo;
+import com.graphy.backend.domain.member.domain.Member;
 import com.graphy.backend.domain.member.repository.MemberRepository;
 import com.graphy.backend.global.error.ErrorCode;
 import com.graphy.backend.global.error.exception.EmptyResultException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -27,18 +26,5 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     private UserDetails createUserDetails(Member member) {
         return new MemberInfo(member);
-    }
-
-    /**
-     * TODO
-     *  Follow, Like 도메인에 사용되는 메서드입니다.
-     *  해당 도메인을 @CurrentUser로 리팩토링 후에 제거 부탁드립니다.
-     */
-    public Member getLoginUser() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String email = ((UserDetails) principal).getUsername();
-        return memberRepository.findByEmail(email).orElseThrow(
-                () -> new EmptyResultException(ErrorCode.MEMBER_NOT_EXIST)
-        );
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/follow/controller/FollowController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/follow/controller/FollowController.java
@@ -1,5 +1,7 @@
 package com.graphy.backend.domain.follow.controller;
 
+import com.graphy.backend.domain.auth.util.annotation.CurrentUser;
+import com.graphy.backend.domain.member.domain.Member;
 import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
 import com.graphy.backend.domain.follow.service.FollowService;
 import com.graphy.backend.global.result.ResultCode;
@@ -22,29 +24,29 @@ public class FollowController {
 
     @Operation(summary = "follow", description = "팔로우 걸기")
     @PostMapping("/{id}")
-    public ResponseEntity<ResultResponse> follow(@PathVariable Long id) {
-        followService.follow(id);
+    public ResponseEntity<ResultResponse> followAdd(@PathVariable Long id, @CurrentUser Member loginUser) {
+        followService.addFollow(id, loginUser);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.FOLLOWING_CREATE_SUCCESS));
     }
 
     @Operation(summary = "unfollow", description = "언팔로우")
     @DeleteMapping("/{id}")
-    public ResponseEntity<ResultResponse> unfollow(@PathVariable Long id) {
-        followService.unfollow(id);
+    public ResponseEntity<ResultResponse> followRemove(@PathVariable Long id, @CurrentUser Member loginUser) {
+        followService.removeFollow(id, loginUser);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.FOLLOW_DELETE_SUCCESS));
     }
 
     @Operation(summary = "Get Follower", description = "팔로워 조회")
     @GetMapping("/follower")
-    public ResponseEntity<ResultResponse> getFollower() {
-        List<GetMemberListResponse> result = followService.getFollowers();
+    public ResponseEntity<ResultResponse> followerList(@CurrentUser Member loginUser) {
+        List<GetMemberListResponse> result = followService.findFollowerList(loginUser);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.FOLLOWER_GET_SUCCESS, result));
     }
 
     @Operation(summary = "Get Following", description = "팔로잉 조회")
     @GetMapping("/following")
-    public ResponseEntity<ResultResponse> getFollowing() {
-        List<GetMemberListResponse> result = followService.getFollowings();
+    public ResponseEntity<ResultResponse> followingList(@CurrentUser Member loginUser) {
+        List<GetMemberListResponse> result = followService.findFollowingList(loginUser);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.FOLLOWER_GET_SUCCESS, result));
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/follow/repository/FollowCustomRepository.java
+++ b/backend/src/main/java/com/graphy/backend/domain/follow/repository/FollowCustomRepository.java
@@ -1,0 +1,10 @@
+package com.graphy.backend.domain.follow.repository;
+
+import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
+
+import java.util.List;
+
+public interface FollowCustomRepository {
+    List<GetMemberListResponse> findFollowers(Long toId);
+    List<GetMemberListResponse> findFollowings(Long fromId);
+}

--- a/backend/src/main/java/com/graphy/backend/domain/follow/repository/FollowCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/graphy/backend/domain/follow/repository/FollowCustomRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.graphy.backend.domain.follow.repository;
+
+import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.graphy.backend.domain.follow.domain.QFollow.follow;
+import static com.graphy.backend.domain.member.domain.QMember.member;
+
+@RequiredArgsConstructor
+public class FollowCustomRepositoryImpl implements FollowCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<GetMemberListResponse> findFollowers(Long toId) {
+        return jpaQueryFactory.select(Projections.constructor(GetMemberListResponse.class,
+                member.id,
+                member.nickname))
+                .from(member)
+                .innerJoin(follow)
+                .on(follow.fromId.eq(member.id))
+                .where(follow.toId.eq(toId))
+                .fetch();
+    }
+
+    @Override
+    public List<GetMemberListResponse> findFollowings(Long fromId) {
+        return jpaQueryFactory.select(Projections.constructor(GetMemberListResponse.class,
+                        member.id,
+                        member.nickname))
+                .from(member)
+                .innerJoin(follow)
+                .on(follow.toId.eq(member.id))
+                .where(follow.fromId.eq(fromId))
+                .fetch();
+    }
+}

--- a/backend/src/main/java/com/graphy/backend/domain/follow/repository/FollowRepository.java
+++ b/backend/src/main/java/com/graphy/backend/domain/follow/repository/FollowRepository.java
@@ -1,30 +1,11 @@
 package com.graphy.backend.domain.follow.repository;
 
 import com.graphy.backend.domain.follow.domain.Follow;
-import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
-public interface FollowRepository extends JpaRepository<Follow, Long> {
+public interface FollowRepository extends JpaRepository<Follow, Long>, FollowCustomRepository {
     boolean existsByFromIdAndToId(Long fromId, Long toId);
     Optional<Follow> findByFromIdAndToId(Long fromId, Long toId);
-
-    /**
-     * TODO
-     * 아래 두 메서드 QueryDSL로 리팩토링 부탁드립니다!
-     */
-    @Query(value = "select m.id, m.nickname " +
-            "from Follow f " +
-            "inner join Member m on m.id = f.from_id " +
-            "where f.to_id = :toId", nativeQuery = true)
-    List<GetMemberListResponse> findFollower(Long toId);
-
-    @Query(value = "select m.id, m.nickname " +
-            "from Follow f " +
-            "inner join Member m on m.id = f.to_id " +
-            "where f.from_id = :fromId", nativeQuery = true)
-    List<GetMemberListResponse> findFollowing(Long fromId);
 }

--- a/backend/src/main/java/com/graphy/backend/domain/follow/repository/custom/FollowCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/graphy/backend/domain/follow/repository/custom/FollowCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
-package com.graphy.backend.domain.follow.repository;
+package com.graphy.backend.domain.follow.repository.custom;
 
+import com.graphy.backend.domain.follow.repository.FollowCustomRepository;
 import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;

--- a/backend/src/main/java/com/graphy/backend/domain/member/dto/response/GetMemberListResponse.java
+++ b/backend/src/main/java/com/graphy/backend/domain/member/dto/response/GetMemberListResponse.java
@@ -4,8 +4,8 @@ import lombok.*;
 
 @Getter
 @Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
+@AllArgsConstructor
 public class GetMemberListResponse {
     private Long id;
     private String nickname;

--- a/backend/src/main/java/com/graphy/backend/domain/project/controller/LikeController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/controller/LikeController.java
@@ -1,5 +1,8 @@
 package com.graphy.backend.domain.project.controller;
 
+import com.graphy.backend.domain.auth.util.annotation.CurrentUser;
+import com.graphy.backend.domain.member.domain.Member;
+import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
 import com.graphy.backend.domain.project.service.LikeService;
 import com.graphy.backend.global.result.ResultCode;
 import com.graphy.backend.global.result.ResultResponse;
@@ -7,8 +10,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "LikeController", description = "좋아요 관련 API")
 @RestController
@@ -21,14 +27,15 @@ public class LikeController {
     @Operation(summary = "findLikedMember", description = "좋아요 누른 유저 조회")
     @GetMapping("/{projectId}")
     public ResponseEntity<ResultResponse> likedMemberList(@PathVariable Long projectId) {
-        likeService.findLikedMemberList(projectId);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.PROJECT_GET_SUCCESS));
+        List<GetMemberListResponse> likedMemberList = likeService.findLikedMemberList(projectId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ResultResponse.of(ResultCode.LIKED_MEMBER_GET_SUCCESS, likedMemberList));
     }
 
     @Operation(summary = "likeProject", description = "좋아요 기능")
     @PutMapping("/{projectId}")
-    public ResponseEntity<ResultResponse> likeProject(@PathVariable Long projectId) {
-        likeService.likeProject(projectId);
+    public ResponseEntity<ResultResponse> likeProject(@PathVariable Long projectId, @CurrentUser Member loginUser) {
+        likeService.likeOrUnlikeProject(projectId, loginUser);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.LIKE_PROJECT_SUCCESS));
     }
 

--- a/backend/src/main/java/com/graphy/backend/domain/project/domain/Project.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/domain/Project.java
@@ -23,7 +23,7 @@ import static javax.persistence.FetchType.LAZY;
 public class Project extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "project_id")
     private Long id;
 

--- a/backend/src/main/java/com/graphy/backend/domain/project/repository/LikeCustomRepository.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/repository/LikeCustomRepository.java
@@ -1,0 +1,10 @@
+package com.graphy.backend.domain.project.repository;
+
+import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
+
+import java.util.List;
+
+public interface LikeCustomRepository {
+
+    List<GetMemberListResponse> findLikedMembers(Long projectId);
+}

--- a/backend/src/main/java/com/graphy/backend/domain/project/repository/LikeRepository.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/repository/LikeRepository.java
@@ -1,25 +1,16 @@
 package com.graphy.backend.domain.project.repository;
 
-import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
 import com.graphy.backend.domain.member.domain.Member;
 import com.graphy.backend.domain.project.domain.Like;
 import com.graphy.backend.domain.project.domain.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface LikeRepository extends JpaRepository<Like, Long> {
+public interface LikeRepository extends JpaRepository<Like, Long>, LikeCustomRepository {
 
     Optional<Like> findByProjectAndMember(Project project, Member member);
-
-    @Query(value = "select m.id, m.nickname " +
-            "from Like l " +
-            "inner join Member m on m.id = l.member_id " +
-            "where l.project_id = :projectId", nativeQuery = true)
-    List<GetMemberListResponse> findLikedMembers(Long projectId);
 }
 

--- a/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/LikeCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/LikeCustomRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.graphy.backend.domain.project.repository.custom;
+
+import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
+import com.graphy.backend.domain.project.repository.LikeCustomRepository;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.graphy.backend.domain.project.domain.QLike.like;
+import static com.graphy.backend.domain.project.domain.QProject.project;
+
+@RequiredArgsConstructor
+public class LikeCustomRepositoryImpl implements LikeCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<GetMemberListResponse> findLikedMembers(Long projectId) {
+        return jpaQueryFactory.select(Projections.constructor(GetMemberListResponse.class,
+                like.member.id,
+                like.member.nickname))
+                .from(like)
+                .leftJoin(like.project, project)
+                .where(project.id.eq(projectId))
+                .fetch();
+    }
+}

--- a/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/ProjectCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/ProjectCustomRepositoryImpl.java
@@ -1,6 +1,7 @@
-package com.graphy.backend.domain.project.repository;
+package com.graphy.backend.domain.project.repository.custom;
 
 import com.graphy.backend.domain.project.domain.Project;
+import com.graphy.backend.domain.project.repository.ProjectCustomRepository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -14,7 +15,7 @@ import java.util.List;
 
 import static com.graphy.backend.domain.project.domain.QProject.project;
 @RequiredArgsConstructor
-public class ProjectCustomRepositoryImpl implements ProjectCustomRepository{
+public class ProjectCustomRepositoryImpl implements ProjectCustomRepository {
 
     private final JPAQueryFactory queryFactory;
 

--- a/backend/src/main/java/com/graphy/backend/domain/project/service/LikeService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/service/LikeService.java
@@ -32,8 +32,8 @@ public class LikeService {
     }
 
     @Transactional
-    public void likeProject(Long projectId) {
-        Long memberId = customUserDetailsService.getLoginUser().getId();
+    public void likeOrUnlikeProject(Long projectId, Member loginUser) {
+        Long memberId = loginUser.getId();
         Member member = memberService.findMemberById(memberId);
         Project project = projectService.getProjectById(projectId);
 

--- a/backend/src/main/java/com/graphy/backend/global/result/ResultCode.java
+++ b/backend/src/main/java/com/graphy/backend/global/result/ResultCode.java
@@ -26,6 +26,7 @@ public enum ResultCode {
 
     // Like
     LIKE_PROJECT_SUCCESS("L001", "프로젝트 좋아요/좋아요 취소 성공"),
+    LIKED_MEMBER_GET_SUCCESS("L002", "좋아요 누른 유저 조회 성공"),
 
     // project
     PROJECT_CREATE_SUCCESS("P001", "프로젝트 생성 성공"),
@@ -41,9 +42,9 @@ public enum ResultCode {
     COMMENT_UPDATE_SUCCESS("C004", "댓글 수정 성공"),
 
     // plan
-    PLAN_CREATE_SUCCESS("PL001", "고도화 계획 생성 성공"),
+    PLAN_CREATE_SUCCESS("PL001", "고도화 계획 생성 성공");
 
-    ;
+
 
     private final String code;
     private final String message;

--- a/backend/src/test/java/com/graphy/backend/domain/follow/controller/FollowControllerTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/follow/controller/FollowControllerTest.java
@@ -56,7 +56,7 @@ public class FollowControllerTest extends MockApiTest {
         Long id = 1L;
 
         //when
-        doNothing().when(followService).follow(id);
+        doNothing().when(followService).addfollow(id);
 
         //then
         mvc.perform(post(baseUrl + "/{id}", id))
@@ -73,7 +73,7 @@ public class FollowControllerTest extends MockApiTest {
         Long id = 1L;
 
         //when
-        doNothing().when(followService).unfollow(id);
+        doNothing().when(followService).removefollow(id);
 
         //then
         mvc.perform(delete(baseUrl + "/{id}", id))
@@ -108,7 +108,7 @@ public class FollowControllerTest extends MockApiTest {
         List<GetMemberListResponse> followingList = Arrays.asList(following1, following2);
 
         // when
-        given(followService.getFollowings()).willReturn(followingList);
+        given(followService.findFollowingList()).willReturn(followingList);
 
         //then
         mvc.perform(get(baseUrl + "/following"))
@@ -125,7 +125,7 @@ public class FollowControllerTest extends MockApiTest {
 
     @Test
     @DisplayName("팔로워 리스트 조회 테스트")
-    public void getFollowerListTest() throws Exception {
+    void getFollowerListTest() throws Exception {
         // given
         GetMemberListResponse follower1 = new GetMemberListResponse() {
             public Long getId() {
@@ -148,7 +148,7 @@ public class FollowControllerTest extends MockApiTest {
         List<GetMemberListResponse> followerList = Arrays.asList(follower1, follower2);
 
         // when
-        given(followService.getFollowers()).willReturn(followerList);
+        given(followService.findFollowerList()).willReturn(followerList);
 
         //then
         mvc.perform(get(baseUrl + "/follower"))

--- a/backend/src/test/java/com/graphy/backend/domain/follow/controller/FollowControllerTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/follow/controller/FollowControllerTest.java
@@ -1,9 +1,10 @@
 package com.graphy.backend.domain.follow.controller;
 
-import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
-import com.graphy.backend.domain.follow.service.FollowService;
 import com.graphy.backend.domain.auth.infra.TokenProvider;
 import com.graphy.backend.domain.auth.repository.RefreshTokenRepository;
+import com.graphy.backend.domain.follow.service.FollowService;
+import com.graphy.backend.domain.member.domain.Member;
+import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
 import com.graphy.backend.test.MockApiTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -28,8 +30,8 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 @WebMvcTest(FollowController.class)
 @ExtendWith(RestDocumentationExtension.class)
 public class FollowControllerTest extends MockApiTest {
@@ -51,12 +53,12 @@ public class FollowControllerTest extends MockApiTest {
 
     @Test
     @DisplayName("팔로우 신청 테스트")
-    public void followTest() throws Exception {
+    void followTest() throws Exception {
         //given
         Long id = 1L;
 
         //when
-        doNothing().when(followService).addfollow(id);
+        doNothing().when(followService).addFollow(id, any(Member.class));
 
         //then
         mvc.perform(post(baseUrl + "/{id}", id))
@@ -68,12 +70,12 @@ public class FollowControllerTest extends MockApiTest {
 
     @Test
     @DisplayName("언팔로우 테스트")
-    public void unfollowTest() throws Exception {
+    void unfollowTest() throws Exception {
         //given
         Long id = 1L;
 
         //when
-        doNothing().when(followService).removefollow(id);
+        doNothing().when(followService).removeFollow(id, any(Member.class));
 
         //then
         mvc.perform(delete(baseUrl + "/{id}", id))
@@ -85,7 +87,7 @@ public class FollowControllerTest extends MockApiTest {
 
     @Test
     @DisplayName("팔로잉 리스트 조회 테스트")
-    public void getFollowingListTest() throws Exception {
+    void getFollowingListTest() throws Exception {
         // given
         GetMemberListResponse following1 = new GetMemberListResponse() {
             public Long getId() {
@@ -108,7 +110,7 @@ public class FollowControllerTest extends MockApiTest {
         List<GetMemberListResponse> followingList = Arrays.asList(following1, following2);
 
         // when
-        given(followService.findFollowingList()).willReturn(followingList);
+        given(followService.findFollowingList(any(Member.class))).willReturn(followingList);
 
         //then
         mvc.perform(get(baseUrl + "/following"))
@@ -148,7 +150,7 @@ public class FollowControllerTest extends MockApiTest {
         List<GetMemberListResponse> followerList = Arrays.asList(follower1, follower2);
 
         // when
-        given(followService.findFollowerList()).willReturn(followerList);
+        given(followService.findFollowerList(any(Member.class))).willReturn(followerList);
 
         //then
         mvc.perform(get(baseUrl + "/follower"))

--- a/backend/src/test/java/com/graphy/backend/domain/follow/domain/FollowTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/follow/domain/FollowTest.java
@@ -1,4 +1,0 @@
-package com.graphy.backend.domain.follow.domain;
-
-public class FollowTest {
-}

--- a/backend/src/test/java/com/graphy/backend/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/member/service/MemberServiceTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 
 @ExtendWith(MockitoExtension.class)
-public class MemberServiceTest extends MockTest {
+class MemberServiceTest extends MockTest {
     @InjectMocks
     private MemberService memberService;
     @Mock

--- a/backend/src/test/java/com/graphy/backend/domain/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/project/service/ProjectServiceTest.java
@@ -134,7 +134,6 @@ public class ProjectServiceTest extends MockTest {
         when(request.toEntity(member)).thenReturn(project);
         when(projectRepository.save(project)).thenReturn(project);
         when(CreateProjectResponse.from(project.getId())).thenReturn(response);
-        when(customUserDetailsService.getLoginUser()).thenReturn(member);
         CreateProjectResponse result = projectService.addProject(request, member);
 
         //then


### PR DESCRIPTION
## 🛠️ 변경사항
- Like 도메인의 findLikedMembers (좋아요한 사용자 조회) JPA의 어노테이션 @Query -> QueryDSL로 변경
- Repository 패키지 구조 수정
    - repository/custom: QueryDSL을 위한 customRepositoryImpl 클래스
    - repository/: 간단한 CRUD를 위한 JPARepository
- Backend Dockerfile 다시 추가
- Follow 도메인의 findFollowing, findFollwers(팔로잉, 팔로우한 사용자 조회) JPA의 어노테이션 @Query -> QueryDSL로 변경
</br>
</br>

## ☝️ 유의사항
- QueryDSL로 리팩토링하다가 컨벤션 하나 필요할 것 같아서 추가해뒀습니다!
![image](https://github.com/techeer-sv/graphy/assets/75435113/3494dd7c-1670-4926-907d-407b4964c5cd)

</br>
</br>

## 👀 참고자료

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
