### PR TITLE
BE/#209 controller mock mvc 테스트를 위한 userdetails 설정

### DIFF
--- a/backend/src/test/java/com/graphy/backend/domain/follow/controller/FollowControllerTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/follow/controller/FollowControllerTest.java
@@ -3,7 +3,9 @@ package com.graphy.backend.domain.follow.controller;
 import com.graphy.backend.domain.auth.util.MemberInfo;
 import com.graphy.backend.domain.follow.service.FollowService;
 import com.graphy.backend.domain.member.domain.Member;
+import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
 import com.graphy.backend.test.MockApiTest;
+import com.graphy.backend.test.util.WithMockCustomUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,15 +19,23 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static com.graphy.backend.domain.member.domain.Role.ROLE_USER;
 import static com.graphy.backend.test.config.ApiDocumentUtil.getDocumentRequest;
 import static com.graphy.backend.test.config.ApiDocumentUtil.getDocumentResponse;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 @WebMvcTest(FollowController.class)
 @ExtendWith(RestDocumentationExtension.class)
@@ -42,7 +52,7 @@ class FollowControllerTest extends MockApiTest {
         memberInfo = new MemberInfo(Member.builder().id(1L).email("test@gmail.com").password("password").role(ROLE_USER).build());
     }
 
-    private static String baseUrl = "/api/v1/follow";
+    private static final String BASE_URL = "/api/v1/follow";
 
     @Test
     @DisplayName("팔로우 신청 테스트")
@@ -51,7 +61,7 @@ class FollowControllerTest extends MockApiTest {
         Long id = 1L;
 
         // when & then
-        mvc.perform(post(baseUrl + "/{id}", id).principal(new TestingAuthenticationToken("testEmail", "testPassword")))
+        mvc.perform(post(BASE_URL + "/{id}", id).principal(new TestingAuthenticationToken("testEmail", "testPassword")))
                 .andExpect(status().isCreated())
                 .andDo(document("follow/add/success",
                         getDocumentRequest(),
@@ -73,7 +83,7 @@ class FollowControllerTest extends MockApiTest {
         Long id = 1L;
 
         //then
-        mvc.perform(RestDocumentationRequestBuilders.delete(baseUrl + "/{id}", id).principal(new TestingAuthenticationToken("testEmail", "testPassword")))
+        mvc.perform(RestDocumentationRequestBuilders.delete(BASE_URL + "/{id}", id).principal(new TestingAuthenticationToken("testEmail", "testPassword")))
                 .andExpect(status().isNoContent())
                 .andDo(document("follow/remove/success",
                         getDocumentRequest(),
@@ -88,84 +98,99 @@ class FollowControllerTest extends MockApiTest {
                         )));
     }
 
-//    @Test
-//    @DisplayName("팔로잉 리스트 조회 테스트")
-//    void getFollowingListTest() throws Exception {
-//        // given
-//        GetMemberListResponse following1 = new GetMemberListResponse() {
-//            public Long getId() {
-//                return 1L;
-//            }
-//            public String getNickname() {
-//                return "memberA";
-//            }
-//        };
-//
-//        GetMemberListResponse following2 = new GetMemberListResponse() {
-//            public Long getId() {
-//                return 2L;
-//            }
-//            public String getNickname() {
-//                return "memberB";
-//            }
-//        };
-//
-//        List<GetMemberListResponse> followingList = Arrays.asList(following1, following2);
-//
-//        // when
-//        given(followService.findFollowingList(any(Member.class))).willReturn(followingList);
-//
-//        //then
-//        mvc.perform(get(baseUrl + "/following").with(user(memberInfo)))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.data", hasSize(2)))
-//                .andExpect(jsonPath("$.data[0].id").exists())
-//                .andExpect(jsonPath("$.data[0].nickname").value("memberA"))
-//                .andExpect(jsonPath("$.data[1].id").exists())
-//                .andExpect(jsonPath("$.data[1].nickname").value("memberB"))
-//                .andDo(document("followingList-get",
-//                        preprocessResponse(prettyPrint()))
-//                );
-//    }
+    @Test
+    @WithMockCustomUser
+    @DisplayName("팔로잉 리스트 조회 테스트")
+    void getFollowingListTest() throws Exception {
+        // given
+        GetMemberListResponse following1 = new GetMemberListResponse() {
+            public Long getId() {
+                return 1L;
+            }
+            public String getNickname() {
+                return "memberA";
+            }
+        };
 
-//    @Test
-//    @WithAnonymousUser
-//    @DisplayName("팔로워 리스트 조회 테스트")
-//    void getFollowerListTest() throws Exception {
-//        // given
-//        GetMemberListResponse follower1 = new GetMemberListResponse() {
-//            public Long getId() {
-//                return 1L;
-//            }
-//            public String getNickname() {
-//                return "memberA";
-//            }
-//        };
-//
-//        GetMemberListResponse follower2 = new GetMemberListResponse() {
-//            public Long getId() {
-//                return 2L;
-//            }
-//            public String getNickname() {
-//                return "memberB";
-//            }
-//        };
-//
-//        List<GetMemberListResponse> followerList = Arrays.asList(follower1, follower2);
-//
-//        // when
-//        given(followService.findFollowerList(any(Member.class))).willReturn(followerList);
-//
-//        //then
-//        mvc.perform(get(baseUrl + "/follower").principal(new TestingAuthenticationToken("testEmail", "testPassword")))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.data", hasSize(2)))
-//                .andExpect(jsonPath("$.data[0].id").exists())
-//                .andExpect(jsonPath("$.data[0].nickname").value("memberA"))
-//                .andExpect(jsonPath("$.data[1].id").exists())
-//                .andExpect(jsonPath("$.data[1].nickname").value("memberB"))
-//                .andDo(document("followerList-get",
-//                        preprocessResponse(prettyPrint()))
-//                );
-//    }
+        GetMemberListResponse following2 = new GetMemberListResponse() {
+            public Long getId() {
+                return 2L;
+            }
+            public String getNickname() {
+                return "memberB";
+            }
+        };
+
+        List<GetMemberListResponse> followingList = Arrays.asList(following1, following2);
+
+        // when
+        given(followService.findFollowingList(any(Member.class))).willReturn(followingList);
+
+        //then
+        mvc.perform(get(BASE_URL + "/following"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].id").exists())
+                .andExpect(jsonPath("$.data[0].nickname").value("memberA"))
+                .andExpect(jsonPath("$.data[1].id").exists())
+                .andExpect(jsonPath("$.data[1].nickname").value("memberB"))
+                .andDo(document("follow/followingList/success",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        responseFields(
+                                fieldWithPath("code").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data").description("응답 데이터"),
+                                fieldWithPath("data[].id").description("팔로잉하는 사용자의 ID"),
+                                fieldWithPath("data[].nickname").description("팔로잉하는 사용자의 nickname")
+                        )));
+    }
+
+    @Test
+    @WithMockCustomUser
+    @DisplayName("팔로워 리스트 조회 테스트")
+    void getFollowerListTest() throws Exception {
+        // given
+        GetMemberListResponse follower1 = new GetMemberListResponse() {
+            public Long getId() {
+                return 1L;
+            }
+            public String getNickname() {
+                return "memberA";
+            }
+        };
+
+        GetMemberListResponse follower2 = new GetMemberListResponse() {
+            public Long getId() {
+                return 2L;
+            }
+            public String getNickname() {
+                return "memberB";
+            }
+        };
+
+        List<GetMemberListResponse> followerList = Arrays.asList(follower1, follower2);
+
+        // when
+        given(followService.findFollowerList(any(Member.class))).willReturn(followerList);
+
+        //then
+        mvc.perform(get(BASE_URL + "/follower").principal(new TestingAuthenticationToken("testEmail", "testPassword")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].id").exists())
+                .andExpect(jsonPath("$.data[0].nickname").value("memberA"))
+                .andExpect(jsonPath("$.data[1].id").exists())
+                .andExpect(jsonPath("$.data[1].nickname").value("memberB"))
+                .andDo(document("follow/followingList/success",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        responseFields(
+                                fieldWithPath("code").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data").description("응답 데이터"),
+                                fieldWithPath("data[].id").description("팔로워 사용자의 ID"),
+                                fieldWithPath("data[].nickname").description("팔로워 사용자의 nickname")
+                                )));
+    }
 }

--- a/backend/src/test/java/com/graphy/backend/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/member/controller/MemberControllerTest.java
@@ -73,7 +73,7 @@ class MemberControllerTest extends MockApiTest {
 
     @Test
     @DisplayName("닉네임으로 사용자를 조회한다")
-    public void findMemberTest() throws Exception {
+    void findMemberTest() throws Exception {
         // given
         GetMemberResponse response1 = GetMemberResponse.builder()
                 .nickname(member1.getNickname())
@@ -122,7 +122,7 @@ class MemberControllerTest extends MockApiTest {
 
     @Test
     @DisplayName("현재 로그인한 사용자의 정보로 마이페이지를 조회한다")
-    public void getMyPageTest() throws Exception {
+    void getMyPageTest() throws Exception {
         GetMyPageResponse result = GetMyPageResponse.builder()
                 .nickname(member1.getNickname())
                 .introduction(member1.getIntroduction())

--- a/backend/src/test/java/com/graphy/backend/domain/project/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/project/controller/ProjectControllerTest.java
@@ -1,11 +1,16 @@
 package com.graphy.backend.domain.project.controller;
 
 import com.graphy.backend.domain.comment.service.CommentService;
+import com.graphy.backend.domain.member.domain.Member;
+import com.graphy.backend.domain.project.dto.request.CreateProjectRequest;
+import com.graphy.backend.domain.project.dto.request.GetProjectPlanRequest;
 import com.graphy.backend.domain.project.dto.request.GetProjectsRequest;
+import com.graphy.backend.domain.project.dto.response.CreateProjectResponse;
 import com.graphy.backend.domain.project.dto.response.GetProjectResponse;
 import com.graphy.backend.domain.project.service.ProjectService;
 import com.graphy.backend.global.config.SecurityConfig;
 import com.graphy.backend.test.MockApiTest;
+import com.graphy.backend.test.util.WithMockCustomUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,9 +20,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -25,24 +30,25 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static com.graphy.backend.test.config.ApiDocumentUtil.getDocumentRequest;
 import static com.graphy.backend.test.config.ApiDocumentUtil.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProjectController.class)
 @ExtendWith(RestDocumentationExtension.class)
-@WithMockUser(username = "yukeon@gmail.com")
 @Import(SecurityConfig.class)
 class ProjectControllerTest extends MockApiTest {
 
@@ -55,7 +61,7 @@ class ProjectControllerTest extends MockApiTest {
     @MockBean
     CommentService commentService;
 
-    private static String baseUrl = "/api/v1/projects";
+    private static final String BASE_URL = "/api/v1/projects";
 
     @BeforeEach
     public void setup(RestDocumentationContextProvider provider) {
@@ -66,43 +72,53 @@ class ProjectControllerTest extends MockApiTest {
     }
 
 
-//    @Test
-//    @DisplayName("프로젝트 생성 테스트")
-//    void createProject() throws Exception {
-//        //given
-//        CreateProjectRequest request = CreateProjectRequest.builder()
-//                .projectName("projectName")
-//                .description("description")
-//                .content("content")
-//                .build();
-//
-//        CreateProjectResponse response = CreateProjectResponse.builder().projectId(1L).build();
-//
-//        //when
-//        when(projectService.addProject(request, new Member())).thenReturn(response);
-//
-//        //then
-//        mvc.perform(post(baseUrl)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(objectMapper.writeValueAsString(request)))
-//                .andExpect(status().isOk())
-//                .andDo(document("project-create",
-//                        preprocessResponse(prettyPrint()))
-//                );
-//    }
+    @Test
+    @WithMockCustomUser
+    @DisplayName("프로젝트 생성 테스트")
+    void createProject() throws Exception {
+        //given
+        CreateProjectRequest request = CreateProjectRequest.builder()
+                .projectName("projectName")
+                .description("description")
+                .content("content")
+                .build();
 
-//    @Test
-//    @DisplayName("프로젝트 삭제 테스트")
-//    void deleteProject() throws Exception {
-//        //given
-//        Long projectId = 1L;
-//
-//        doNothing().when(projectService).removeProject(anyLong());
-//
-//        mvc.perform(delete(baseUrl + "/{projectId}", 1L)
-//                        .contentType(MediaType.APPLICATION_JSON))
-//                .andExpect(status().isOk());
-//    }
+        CreateProjectResponse response = CreateProjectResponse.builder().projectId(1L).build();
+
+        //when
+        when(projectService.addProject(request, new Member())).thenReturn(response);
+
+        //then
+        mvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andDo(document("project/add/success",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        requestFields(
+                                fieldWithPath("projectName").description("프로젝트 이름"),
+                                fieldWithPath("description").description("프로젝트 설명"),
+                                fieldWithPath("content").description("프로젝트 내용"),
+                                fieldWithPath("techTags").description("기술 스택"),
+                                fieldWithPath("thumbNail").description("썸네일")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data").description("응답 데이터")
+                        )));
+    }
+
+    @Test
+    @WithMockCustomUser
+    @DisplayName("프로젝트 삭제 테스트")
+    void deleteProject() throws Exception {
+
+        mvc.perform(delete(BASE_URL + "/{projectId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
 
     @Test
     @DisplayName("프로젝트 이름/내용/전체 검색한다")
@@ -111,10 +127,8 @@ class ProjectControllerTest extends MockApiTest {
         // given
         String projectName = "검색이름";
 
-        GetProjectsRequest request = GetProjectsRequest.builder()
-                .projectName(projectName).build();
 
-        List<GetProjectResponse> result = new ArrayList<GetProjectResponse>();
+        List<GetProjectResponse> result = new ArrayList<>();
 
         for (int i = 0; i < 5; i++) {
             GetProjectResponse response =
@@ -130,7 +144,7 @@ class ProjectControllerTest extends MockApiTest {
         info.add("size", "5");
 
         // when & then
-        mvc.perform(get(baseUrl).params(info))
+        mvc.perform(get(BASE_URL).params(info))
                 .andExpect(status().isOk())
                 .andDo(document("project/list/success",
                         getDocumentRequest(),
@@ -154,29 +168,30 @@ class ProjectControllerTest extends MockApiTest {
                         )));
     }
 
-//    @Test
-//    @DisplayName("프로젝트 고도화 계획을 제안 받는다")
-//    void getProjectPlan() throws Exception {
-//
-//        // given
-//        List<String> features = new ArrayList<>(Arrays.asList("게시물 업로드", "좋아요 누르는 기능"));
-//        List<String> techStacks = new ArrayList<>(Arrays.asList("Springboot", "React", "mySQL"));
-//        List<String> plans = new ArrayList<>(Arrays.asList("Spring Security", "Docker"));
-//        String topic = "간단한 게시판";
-//
-//        GetProjectPlanRequest request = new GetProjectPlanRequest(topic, features, techStacks, plans);
-//
-//        String apiResult = "API 결과";
-//        CompletableFuture<String> result = CompletableFuture.completedFuture(apiResult);
-//
-//        given(projectService.getProjectPlanAsync(any())).willReturn(result);
-//
-//        // when
-//        String body = objectMapper.writeValueAsString(request);
-//        mvc.perform(post(baseUrl+"/plans").principal(new TestingAuthenticationToken("testEmail", "testPassword"))
-//                .content(objectMapper.writeValueAsString(request))
-//                .contentType(MediaType.APPLICATION_JSON))
-//                .andExpect(status().isOk());
-//
-//    }
+    @Test
+    @WithMockCustomUser
+    @DisplayName("프로젝트 고도화 계획을 제안 받는다")
+    void getProjectPlan() throws Exception {
+
+        // given
+        List<String> features = new ArrayList<>(Arrays.asList("게시물 업로드", "좋아요 누르는 기능"));
+        List<String> techStacks = new ArrayList<>(Arrays.asList("Springboot", "React", "mySQL"));
+        List<String> plans = new ArrayList<>(Arrays.asList("Spring Security", "Docker"));
+        String topic = "간단한 게시판";
+
+        GetProjectPlanRequest request = new GetProjectPlanRequest(topic, features, techStacks, plans);
+
+        String apiResult = "API 결과";
+        CompletableFuture<String> result = CompletableFuture.completedFuture(apiResult);
+
+        given(projectService.getProjectPlanAsync(any())).willReturn(result);
+
+        // when
+
+        mvc.perform(post(BASE_URL +"/plans")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+    }
 }

--- a/backend/src/test/java/com/graphy/backend/test/security/WithMockCustomUserSecurityContextFactory.java
+++ b/backend/src/test/java/com/graphy/backend/test/security/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,30 @@
+package com.graphy.backend.test.security;
+
+import com.graphy.backend.domain.auth.util.MemberInfo;
+import com.graphy.backend.domain.member.domain.Member;
+import com.graphy.backend.test.util.WithMockCustomUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+        @Override
+        public SecurityContext createSecurityContext(WithMockCustomUser withMockCustomUser) {
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+            grantedAuthorities.add((GrantedAuthority) () -> "ROLE_USER");
+            Member member = Member.builder().id(1L).email("testEamil").password("testPassword").build();
+            MemberInfo memberInfo = new MemberInfo(member);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(memberInfo, "testPassword", grantedAuthorities);
+            context.setAuthentication(authentication);
+            return context;
+        }
+}

--- a/backend/src/test/java/com/graphy/backend/test/util/WithMockCustomUser.java
+++ b/backend/src/test/java/com/graphy/backend/test/util/WithMockCustomUser.java
@@ -1,0 +1,12 @@
+package com.graphy.backend.test.util;
+
+import com.graphy.backend.test.security.WithMockCustomUserSecurityContextFactory;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+}


### PR DESCRIPTION
## 🛠️ 변경사항
![image](https://github.com/techeer-sv/graphy/assets/75435113/7c2ab2ac-3da6-4a5c-a0e0-50daebd066d2)
- WithMockCustomUser 어노테이션 추가
- WithMockCustomSecurityContextFactory 클래스 추가
- 로그인 사용자가 필요한 mock mvc 테스트 수정
- 사용하지 않는 변수 삭제 및 불필요한 public 접근 제어자 삭제
</br> 
</br>

## ☝️ 유의사항

</br>
</br>

## 👀 참고자료
https://velog.io/@kimhalin/AuthenticationPrincipal-Controller-Test
</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
