### PR TITLE
BE/#211 팔로잉 피드 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/graphy/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.graphy.backend.domain.member.dto.response.GetMemberResponse;
 import com.graphy.backend.domain.member.dto.response.GetMyPageResponse;
 import com.graphy.backend.domain.member.service.MemberService;
 import com.graphy.backend.domain.auth.util.annotation.CurrentUser;
+import com.graphy.backend.domain.project.service.ProjectService;
 import com.graphy.backend.global.result.ResultCode;
 import com.graphy.backend.global.result.ResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,6 +24,7 @@ import java.util.List;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberController {
     private final MemberService memberService;
+    private final ProjectService projectService;
 
     @Operation(summary = "get member", description = "사용자 조회")
     @GetMapping()
@@ -34,7 +36,7 @@ public class MemberController {
     @Operation(summary = "myPage", description = "마이페이지")
     @GetMapping("/mypage")
     public ResponseEntity<ResultResponse> myPage(@CurrentUser Member member) {
-        GetMyPageResponse result = memberService.myPage(member);
+        GetMyPageResponse result = projectService.myPage(member);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.MYPAGE_GET_SUCCESS, result));
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/member/service/MemberService.java
@@ -2,10 +2,7 @@ package com.graphy.backend.domain.member.service;
 
 import com.graphy.backend.domain.member.domain.Member;
 import com.graphy.backend.domain.member.dto.response.GetMemberResponse;
-import com.graphy.backend.domain.member.dto.response.GetMyPageResponse;
 import com.graphy.backend.domain.member.repository.MemberRepository;
-import com.graphy.backend.domain.project.dto.response.GetProjectInfoResponse;
-import com.graphy.backend.domain.project.service.ProjectService;
 import com.graphy.backend.global.error.ErrorCode;
 import com.graphy.backend.global.error.exception.AlreadyExistException;
 import com.graphy.backend.global.error.exception.EmptyResultException;
@@ -15,7 +12,6 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.graphy.backend.global.error.ErrorCode.MEMBER_NOT_EXIST;
@@ -25,7 +21,6 @@ import static com.graphy.backend.global.error.ErrorCode.MEMBER_NOT_EXIST;
 @Transactional
 public class MemberService {
     private final MemberRepository memberRepository;
-    private final ProjectService projectService;
 
 
     public List<GetMemberResponse> findMemberList(String nickname) {
@@ -38,11 +33,6 @@ public class MemberService {
     public Member findMemberById(Long id) {
         return memberRepository.findById(id).orElseThrow(()
                 -> new EmptyResultException(MEMBER_NOT_EXIST));
-    }
-
-    public GetMyPageResponse myPage(Member member) {
-        List<GetProjectInfoResponse> projectInfoList = projectService.findProjectInfoList(member.getId());
-        return GetMyPageResponse.of(member, projectInfoList);
     }
 
     public void checkEmailDuplicate(String email) {

--- a/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
@@ -74,6 +74,16 @@ public class ProjectController {
         return ResponseEntity.ok(ResultResponse.of(ResultCode.PROJECT_PAGING_GET_SUCCESS, result));
     }
 
+    @Operation(summary = "findFollowingProjectList", description = "팔로잉하고 있는 사용자의 프로젝트 조회")
+    @GetMapping("/following")
+    public ResponseEntity<ResultResponse> projectList(PageRequest pageRequest, @CurrentUser Member loginUser){
+        Pageable pageable = pageRequest.of();
+        List<GetProjectResponse> result = projectService.findFollowingProjectList(loginUser, pageable);
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.PROJECT_PAGING_GET_SUCCESS, result));
+    }
+
+
     @Operation(summary = "findProject", description = "프로젝트 상세 조회")
     @GetMapping("/{projectId}")
     public ResponseEntity<ResultResponse> projectDetails(@PathVariable Long projectId) {
@@ -88,9 +98,7 @@ public class ProjectController {
         projectService.checkGptRequestToken(prompt);
 
         CompletableFuture<String> futureResult =
-                projectService.getProjectPlanAsync(prompt).thenApply(result -> {
-                    return result;
-                });
+                projectService.getProjectPlanAsync(prompt).thenApply(result -> result);
         String response = futureResult.get();
 
         return ResponseEntity.ok(ResultResponse.of(ResultCode.PLAN_CREATE_SUCCESS, response));

--- a/backend/src/main/java/com/graphy/backend/domain/project/repository/ProjectCustomRepository.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/repository/ProjectCustomRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.domain.Pageable;
 
 public interface ProjectCustomRepository {
     Page<Project> searchProjectsWith(Pageable pageable, String projectName, String content);
+
+    Page<Project> findFollowingProjects(Pageable pageable, Long fromId);
 }

--- a/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/ProjectCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/ProjectCustomRepositoryImpl.java
@@ -4,36 +4,57 @@ import com.graphy.backend.domain.project.domain.Project;
 import com.graphy.backend.domain.project.repository.ProjectCustomRepository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
-
 import java.util.List;
 
+import static com.graphy.backend.domain.follow.domain.QFollow.follow;
 import static com.graphy.backend.domain.project.domain.QProject.project;
+import static com.querydsl.jpa.JPAExpressions.select;
+
 @RequiredArgsConstructor
 public class ProjectCustomRepositoryImpl implements ProjectCustomRepository {
 
-    private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory jpaQueryFactory;
 
 
     @Override
     public Page<Project> searchProjectsWith(Pageable pageable, String projectName, String content) {
-        List<Project> fetch = queryFactory
+        List<Project> fetch = jpaQueryFactory
                 .selectFrom(project).where(projectNameLike(projectName), contentLike(content))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        JPQLQuery<Project> count = queryFactory
+        JPQLQuery<Project> count = jpaQueryFactory
                 .select(project)
                 .from(project)
                 .where(projectNameLike(projectName), contentLike(content));
 
         return PageableExecutionUtils.getPage(fetch, pageable, count::fetchCount);
+    }
+
+    @Override
+    public Page<Project> findFollowingProjects(Pageable pageable, Long fromId) {
+        List<Project> fetch = jpaQueryFactory.selectFrom(project)
+                .where(project.member.id.in(
+                        select(follow.toId).from(follow).where(follow.fromId.eq(fromId)
+                )))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        JPAQuery<Long> count = jpaQueryFactory
+                .select(project.count())
+                .from(project)
+                .where(project.member.id.in(
+                        select(follow.toId).from(follow).where(follow.fromId.eq(fromId)
+                        )));
+        return PageableExecutionUtils.getPage(fetch, pageable, count::fetchOne);
     }
 
     private BooleanExpression projectNameLike(String projectName) {

--- a/backend/src/test/java/com/graphy/backend/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/member/controller/MemberControllerTest.java
@@ -6,6 +6,7 @@ import com.graphy.backend.domain.member.dto.response.GetMemberResponse;
 import com.graphy.backend.domain.member.dto.response.GetMyPageResponse;
 import com.graphy.backend.domain.member.service.MemberService;
 import com.graphy.backend.domain.project.dto.response.GetProjectInfoResponse;
+import com.graphy.backend.domain.project.service.ProjectService;
 import com.graphy.backend.test.MockApiTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -41,7 +42,10 @@ class MemberControllerTest extends MockApiTest {
     private WebApplicationContext context;
     @MockBean
     MemberService memberService;
-    private static String BASE_URL = "/api/v1/members";
+    @MockBean
+    ProjectService projectService;
+
+    private static final String BASE_URL = "/api/v1/members";
 
     private Member member1;
     private Member member2;
@@ -135,7 +139,7 @@ class MemberControllerTest extends MockApiTest {
                 .build();
 
         // when
-        when(memberService.myPage(any())).thenReturn(result);
+        when(projectService.myPage(any())).thenReturn(result);
 
 
         // then

--- a/backend/src/test/java/com/graphy/backend/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/member/service/MemberServiceTest.java
@@ -62,7 +62,7 @@ class MemberServiceTest extends MockTest {
 
     @Test
     @DisplayName("닉네임으로 사용자 목록을 조회한다")
-    public void findMemberListTest() throws Exception {
+    void findMemberListTest() {
         // given
         List<Member> memberList = Arrays.asList(member1, member2);
         
@@ -78,7 +78,7 @@ class MemberServiceTest extends MockTest {
 
     @Test
     @DisplayName("닉네임으로 사용자 목록을 조회 시 일치하는 사용자가 없으면 빈 목록이 반환된다")
-    public void findMemberListEmptyListTest() throws Exception {
+    void findMemberListEmptyListTest() {
         // given
         String 존재하지_않는_닉네임 = "emptyListNickname";
 
@@ -94,7 +94,7 @@ class MemberServiceTest extends MockTest {
 
     @Test
     @DisplayName("사용자 ID로 사용자를 조회한다")
-    public void findMemberByIdTest() throws Exception {
+    void findMemberByIdTest() {
         // when
         when(memberRepository.findById(member1.getId())).thenReturn(Optional.ofNullable(member1));
         Member actual = memberService.findMemberById(member1.getId());
@@ -105,7 +105,7 @@ class MemberServiceTest extends MockTest {
 
     @Test
     @DisplayName("사용자 ID로 사용자를 조회 시 사용자가 존재하지 않으면 예외가 발생한다")
-    public void findMemberByIdNotExistMemberExceptionTest() throws Exception {
+    void findMemberByIdNotExistMemberExceptionTest() {
         // given
         Long 존재하지_않는_사용자_ID = 0L;
 
@@ -118,7 +118,7 @@ class MemberServiceTest extends MockTest {
 
     @Test
     @DisplayName("현재 로그인한 사용자를 상세 조회한다")
-    public void myPageTest() throws Exception {
+    void myPageTest() {
         // given
         GetProjectInfoResponse response1 = GetProjectInfoResponse.builder()
                 .id(1L)
@@ -136,7 +136,7 @@ class MemberServiceTest extends MockTest {
 
         // when
         when(projectService.findProjectInfoList(member1.getId())).thenReturn(responseList);
-        GetMyPageResponse actual = memberService.myPage(member1);
+        GetMyPageResponse actual = projectService.myPage(member1);
 
         // then
         assertThat(actual.getNickname()).isEqualTo(member1.getNickname());
@@ -151,7 +151,7 @@ class MemberServiceTest extends MockTest {
 
     @Test
     @DisplayName("이메일이 중복된 경우 예외가 발생한다")
-    public void checkEmailDuplicateTest() throws Exception {
+    void checkEmailDuplicateTest() {
         // given
         String 중복된_이메일 = member1.getEmail();
 
@@ -167,7 +167,7 @@ class MemberServiceTest extends MockTest {
 
     @Test
     @DisplayName("사용자를 저장한다")
-    public void addMemberTest() throws Exception {
+    void addMemberTest() {
         // when, then
         assertDoesNotThrow(() -> memberService.addMember(member1));
     }

--- a/backend/src/test/java/com/graphy/backend/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/member/service/MemberServiceTest.java
@@ -3,10 +3,7 @@ package com.graphy.backend.domain.member.service;
 import com.graphy.backend.domain.member.domain.Member;
 import com.graphy.backend.domain.member.domain.Role;
 import com.graphy.backend.domain.member.dto.response.GetMemberResponse;
-import com.graphy.backend.domain.member.dto.response.GetMyPageResponse;
 import com.graphy.backend.domain.member.repository.MemberRepository;
-import com.graphy.backend.domain.project.dto.response.GetProjectInfoResponse;
-import com.graphy.backend.domain.project.service.ProjectService;
 import com.graphy.backend.global.error.exception.AlreadyExistException;
 import com.graphy.backend.global.error.exception.EmptyResultException;
 import com.graphy.backend.test.MockTest;
@@ -18,7 +15,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -32,8 +32,6 @@ class MemberServiceTest extends MockTest {
     private MemberService memberService;
     @Mock
     private MemberRepository memberRepository;
-    @Mock
-    private ProjectService projectService;
 
     private Member member1;
     private Member member2;
@@ -114,39 +112,6 @@ class MemberServiceTest extends MockTest {
                 () -> memberService.findMemberById(존재하지_않는_사용자_ID))
                 .isInstanceOf(EmptyResultException.class)
                 .hasMessageContaining("존재하지 않는 사용자");
-    }
-
-    @Test
-    @DisplayName("현재 로그인한 사용자를 상세 조회한다")
-    void myPageTest() {
-        // given
-        GetProjectInfoResponse response1 = GetProjectInfoResponse.builder()
-                .id(1L)
-                .projectName("project1")
-                .description("description1")
-                .build();
-
-        GetProjectInfoResponse response2 = GetProjectInfoResponse.builder()
-                .id(2L)
-                .projectName("project2")
-                .description("description2")
-                .build();
-
-        List<GetProjectInfoResponse> responseList = Arrays.asList(response1, response2);
-
-        // when
-        when(projectService.findProjectInfoList(member1.getId())).thenReturn(responseList);
-        GetMyPageResponse actual = projectService.myPage(member1);
-
-        // then
-        assertThat(actual.getNickname()).isEqualTo(member1.getNickname());
-        assertThat(actual.getIntroduction()).isEqualTo(member1.getIntroduction());
-        assertThat(actual.getFollowerCount()).isEqualTo(member1.getFollowerCount());
-        assertThat(actual.getFollowingCount()).isEqualTo(member1.getFollowingCount());
-
-        assertThat(actual.getGetProjectInfoResponseList())
-                .usingRecursiveComparison()
-                .isEqualTo(responseList);
     }
 
     @Test


### PR DESCRIPTION
## 🛠️ 변경사항
- custom repository에 팔로잉하고 있는 사용자의 프로젝트 pagination 조회 코드 추가
- member service와 project service 순환 참조 오류 해결
    - mypage 메소드 MemberService -> ProjectService
- 팔로잉 피드 조회 endpoint 추가
![image](https://github.com/techeer-sv/graphy/assets/75435113/b3e6f4f8-c787-47d8-b176-8f9e1936e548)

</br>
</br>

## ☝️ 유의사항

</br>
</br>

## 👀 참고자료

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
