### PR TITLE
BE/#224 팔로우 시, 팔로우한 사용자에게 알림 전송 기능 구현

### DIFF
--- a/backend/src/main/java/com/graphy/backend/domain/follow/service/FollowService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/follow/service/FollowService.java
@@ -50,9 +50,12 @@ public class FollowService {
         return followRepository.findFollowings(loginUser.getId());
     }
 
-    public void checkFollowingAlready(Long fromId, Long toId) {
+    public void checkFollowAvailable(Long fromId, Long toId) {
         if (followRepository.existsByFromIdAndToId(fromId, toId)) {
             throw new AlreadyExistException(ErrorCode.FOLLOW_ALREADY_EXIST);
+        }
+        if (fromId.equals(toId)) {
+            throw new AlreadyExistException(ErrorCode.FOLLOW_SELF);
         }
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/follow/service/FollowService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/follow/service/FollowService.java
@@ -5,39 +5,63 @@ import com.graphy.backend.domain.follow.repository.FollowRepository;
 import com.graphy.backend.domain.member.domain.Member;
 import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
 import com.graphy.backend.domain.member.repository.MemberRepository;
+import com.graphy.backend.domain.member.service.MemberService;
+import com.graphy.backend.domain.notification.domain.NotificationType;
+import com.graphy.backend.domain.notification.dto.NotificationDto;
+import com.graphy.backend.domain.notification.service.NotificationService;
 import com.graphy.backend.global.error.ErrorCode;
 import com.graphy.backend.global.error.exception.AlreadyExistException;
 import com.graphy.backend.global.error.exception.EmptyResultException;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 import java.util.List;
 
 
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class FollowService {
     private final FollowRepository followRepository;
     private final MemberRepository memberRepository;
 
+    private final NotificationService notificationService;
+    private final MemberService memberService;
+
+
+    @Transactional
     public void addFollow(Long toId, Member loginUser) {
+        memberService.findMemberById(loginUser.getId());
+
         Long fromId = loginUser.getId();
-        checkFollowingAlready(loginUser.getId(), toId);
+        checkFollowAvailable(loginUser.getId(), toId);
+
         Follow follow = Follow.builder().fromId(fromId).toId(toId).build();
+        NotificationType notificationType = NotificationType.FOLLOW;
+        notificationType.setMessage(loginUser.getNickname(), "");
+        NotificationDto notificationDto = NotificationDto.builder()
+                .type(notificationType)
+                .content(notificationType.getMessage())
+                .build();
+
         followRepository.save(follow);
         memberRepository.increaseFollowerCount(toId);
         memberRepository.increaseFollowingCount(fromId);
+
+        notificationService.addNotification(notificationDto, toId);
     }
 
+    @Transactional
     public void removeFollow(Long toId, Member loginUser) {
         Long fromId = loginUser.getId();
         Follow follow = followRepository.findByFromIdAndToId(fromId, toId).orElseThrow(
                 () -> new EmptyResultException(ErrorCode.FOLLOW_NOT_EXIST)
         );
         followRepository.delete(follow);
+
+        // TODO: memberService의 메소드로 분리
         memberRepository.decreaseFollowerCount(toId);
         memberRepository.decreaseFollowingCount(fromId);
     }

--- a/backend/src/main/java/com/graphy/backend/domain/notification/domain/Notification.java
+++ b/backend/src/main/java/com/graphy/backend/domain/notification/domain/Notification.java
@@ -1,0 +1,42 @@
+package com.graphy.backend.domain.notification.domain;
+
+import com.graphy.backend.domain.member.domain.Member;
+import com.graphy.backend.global.common.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@SQLDelete(sql = "UPDATE notification SET is_deleted = true WHERE notification_id = ?")
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private boolean isRead;
+
+    @Column(nullable = false)
+    private boolean isEmailSent;
+}

--- a/backend/src/main/java/com/graphy/backend/domain/notification/domain/NotificationType.java
+++ b/backend/src/main/java/com/graphy/backend/domain/notification/domain/NotificationType.java
@@ -1,0 +1,18 @@
+package com.graphy.backend.domain.notification.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationType {
+    RECRUITMENT("님이 팀 합류를 "), // 팀원 모집 글 관련 알림 (지원 신청, 지원 신청 수락)
+    FOLLOW("님이 팔로우하였습니다."),          // 팔로우 관련 알림(본인을 팔로우하는 사용자가 발생 시)
+    MESSAGE("님이 쪽지를 보냈습니다.");                                       // 쪽지 알림 (쪽지 수신 시)
+
+    private String message;
+
+    public void setMessage(String username, String extraMessage) {
+        this.message = username + message +extraMessage;
+    }
+}

--- a/backend/src/main/java/com/graphy/backend/domain/notification/dto/NotificationDto.java
+++ b/backend/src/main/java/com/graphy/backend/domain/notification/dto/NotificationDto.java
@@ -6,7 +6,6 @@ import com.graphy.backend.domain.notification.domain.NotificationType;
 import lombok.*;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -16,6 +15,10 @@ public class NotificationDto {
     private String content;
     private boolean isRead = false;
     private boolean isEmailSent = false;
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
 
     public Notification toEntity() {
         return Notification.builder()

--- a/backend/src/main/java/com/graphy/backend/domain/notification/dto/NotificationDto.java
+++ b/backend/src/main/java/com/graphy/backend/domain/notification/dto/NotificationDto.java
@@ -1,0 +1,30 @@
+package com.graphy.backend.domain.notification.dto;
+
+import com.graphy.backend.domain.member.domain.Member;
+import com.graphy.backend.domain.notification.domain.Notification;
+import com.graphy.backend.domain.notification.domain.NotificationType;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationDto {
+    private NotificationType type;
+    private Member member;
+    private String content;
+    private boolean isRead = false;
+    private boolean isEmailSent = false;
+
+    public Notification toEntity() {
+        return Notification.builder()
+                .type(type)
+                .member(member)
+                .content(content)
+                .isRead(this.isRead)
+                .isEmailSent(this.isEmailSent)
+                .build();
+    }
+}
+

--- a/backend/src/main/java/com/graphy/backend/domain/notification/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/graphy/backend/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.graphy.backend.domain.notification.repository;
+
+import com.graphy.backend.domain.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/backend/src/main/java/com/graphy/backend/domain/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/notification/service/NotificationService.java
@@ -1,0 +1,25 @@
+package com.graphy.backend.domain.notification.service;
+
+import com.graphy.backend.domain.member.domain.Member;
+import com.graphy.backend.domain.member.service.MemberService;
+import com.graphy.backend.domain.notification.dto.NotificationDto;
+import com.graphy.backend.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+    private final MemberService memberService;
+
+    @Transactional
+    public void addNotification(NotificationDto dto, Long memberId) {
+        Member member = memberService.findMemberById(memberId);
+        dto.setMember(member);
+
+        notificationRepository.save(dto.toEntity());
+    }
+}

--- a/backend/src/main/java/com/graphy/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/graphy/backend/global/error/ErrorCode.java
@@ -22,7 +22,9 @@ public enum ErrorCode {
 
   // Follow
   FOLLOW_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "F001", "이미 존재하는 팔로우"),
-  FOLLOW_NOT_EXIST(HttpStatus.NOT_FOUND, "M002", "존재하지 않는 팔로우"),
+  FOLLOW_NOT_EXIST(HttpStatus.NOT_FOUND, "F002", "존재하지 않는 팔로우"),
+  FOLLOW_SELF(HttpStatus.CONFLICT, "F003", "자기 자신을 팔로우 할 수 없음"),
+
   // Project
   PROJECT_DELETED_OR_NOT_EXIST(HttpStatus.NOT_FOUND, "P001", "이미 삭제되거나 존재하지 않는 프로젝트"),
 

--- a/backend/src/test/java/com/graphy/backend/domain/follow/service/FollowServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/follow/service/FollowServiceTest.java
@@ -5,6 +5,8 @@ import com.graphy.backend.domain.follow.repository.FollowRepository;
 import com.graphy.backend.domain.member.domain.Member;
 import com.graphy.backend.domain.member.dto.response.GetMemberListResponse;
 import com.graphy.backend.domain.member.repository.MemberRepository;
+import com.graphy.backend.domain.member.service.MemberService;
+import com.graphy.backend.domain.notification.service.NotificationService;
 import com.graphy.backend.global.error.exception.AlreadyExistException;
 import com.graphy.backend.global.error.exception.EmptyResultException;
 import com.graphy.backend.test.MockTest;
@@ -30,6 +32,12 @@ class FollowServiceTest extends MockTest {
     FollowRepository followRepository;
     @Mock
     MemberRepository memberRepository;
+
+    @Mock
+    NotificationService notificationService;
+    @Mock
+    MemberService memberService;
+
     @InjectMocks
     FollowService followService;
 
@@ -43,6 +51,9 @@ class FollowServiceTest extends MockTest {
         //when
         doNothing().when(memberRepository).increaseFollowingCount(fromMember.getId());
         doNothing().when(memberRepository).increaseFollowerCount(toId);
+        doNothing().when(notificationService).addNotification(any(), any());
+        when(memberService.findMemberById(fromMember.getId())).thenReturn(fromMember);
+
         followService.addFollow(toId, fromMember);
 
         //then

--- a/backend/src/test/java/com/graphy/backend/domain/follow/service/FollowServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/follow/service/FollowServiceTest.java
@@ -21,8 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,7 +35,7 @@ class FollowServiceTest extends MockTest {
 
     @Test
     @DisplayName("팔로우 신청 테스트")
-    void followTest() throws Exception {
+    void followTest() {
         //given
         Member fromMember = Member.builder().id(1L).build();
         Long toId = 2L;
@@ -52,7 +51,7 @@ class FollowServiceTest extends MockTest {
 
     @Test
     @DisplayName("팔로잉 리스트 조회 테스트")
-    void getFollowingListTest() throws Exception {
+    void getFollowingListTest() {
         //given
         Member fromMember = Member.builder().id(1L).build();
         GetMemberListResponse following1 = new GetMemberListResponse() {
@@ -87,7 +86,7 @@ class FollowServiceTest extends MockTest {
 
     @Test
     @DisplayName("팔로워 리스트 조회 테스트")
-    void getFollowerListTest() throws Exception {
+    void getFollowerListTest() {
         //given
         Member toMember = Member.builder().id(1L).build();
         GetMemberListResponse follower1 = new GetMemberListResponse() {
@@ -122,7 +121,7 @@ class FollowServiceTest extends MockTest {
 
     @Test
     @DisplayName("언팔로우 테스트")
-    void unfollowTest() throws Exception {
+    void unfollowTest() {
         //given
         Long toId = 1L;
         Member fromMember = Member.builder().id(2L).build();
@@ -149,31 +148,28 @@ class FollowServiceTest extends MockTest {
                 .thenReturn(Optional.empty());
 
         // when
-        Exception exception = assertThrows(EmptyResultException.class, () -> {
-            followService.removeFollow(toId, fromMember);
-        });
+        Exception exception = assertThrows(EmptyResultException.class, () -> followService.removeFollow(toId, fromMember));
 
         // then
         String exceptionMessage = exception.getMessage();
 
-        assertTrue(exceptionMessage.equals("존재하지 않는 팔로우"));
+        assertEquals("존재하지 않는 팔로우", exceptionMessage);
     }
 
     @Test
     @DisplayName("팔로우 여부 체크 테스트")
-    void followingCheckTest() throws Exception {
+    void followingCheckTest() {
         // given
         when(followRepository.existsByFromIdAndToId(1L, 2L)).thenReturn(true);
         when(followRepository.existsByFromIdAndToId(3L, 4L)).thenReturn(false);
 
         // when & then
-        Member loginUser = new Member();
         assertThatThrownBy(
-                        () -> followService.checkFollowingAlready(1L, 2L))
+                        () -> followService.checkFollowAvailable(1L, 2L))
                 .isInstanceOf(AlreadyExistException.class)
                 .hasMessageContaining("이미 존재하는 팔로우");
 
-        Assertions.assertThatCode(() -> followService.checkFollowingAlready(3L, 4L))
+        Assertions.assertThatCode(() -> followService.checkFollowAvailable(3L, 4L))
                 .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
## 🛠️ 변경사항
- 알림 메시지를 저장하는 Notification 엔티티 추가
    - isRead: 사용자의 읽음 여부, isEmailSent: 이메일 알림의 전송 여부
    - notification의 service, repository 클래스 추가
- 알림 타입은 총 3종류로 정해놨습니다.
    - RECRUITMENT: 팀원 모집 글 관련 알림 (지원 신청, 지원 신청 수락)
    - FOLLOW: 팔로우 관련 알림(본인을 팔로우하는 사용자가 발생 시)
    - MESSAGE: 쪽지 알림 (쪽지 수신 시)
    - NotificationType의 메시지는 알림의 내용을 생성하기 위한 공통 문장으로 보시면 됩니다.
 - 사용자가 다른 사용자를 팔로우할 경우, 알림 테이블에 알림 데이터를 생성해 알림이 발생하도록 구현했습니다
 - 이메일 전송 기능은 따로 브랜치를 생성해 진행할 예정입니다.
</br>
</br>

## ☝️ 유의사항

</br>
</br>

## 👀 참고자료

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
