### PR TITLE
BE/#257 프로젝트 목록 조회 시 검색이 제대로 되지 않는 오류 수정

### DIFF
--- a/backend/src/main/java/com/graphy/backend/domain/project/dto/request/GetProjectsRequest.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/dto/request/GetProjectsRequest.java
@@ -1,11 +1,9 @@
 package com.graphy.backend.domain.project.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/ProjectCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/ProjectCustomRepositoryImpl.java
@@ -58,10 +58,10 @@ public class ProjectCustomRepositoryImpl implements ProjectCustomRepository {
     }
 
     private BooleanExpression projectNameLike(String projectName) {
-        return projectName != null ? project.projectName.eq(projectName) : null;
+        return projectName != null ? project.projectName.contains(projectName) : null;
     }
 
     private BooleanExpression contentLike(String content) {
-        return content != null ? project.content.eq(content) : null;
+        return content != null ? project.content.contains(content) : null;
     }
 }

--- a/backend/src/main/java/com/graphy/backend/global/common/PageRequest.java
+++ b/backend/src/main/java/com/graphy/backend/global/common/PageRequest.java
@@ -1,21 +1,24 @@
 package com.graphy.backend.global.common;
 
+import com.graphy.backend.global.error.exception.BusinessException;
 import org.springframework.data.domain.Sort;
+
+import static com.graphy.backend.global.error.ErrorCode.INPUT_INVALID_VALUE;
 
 
 public class PageRequest {
+    private static final int DEFAULT_SIZE = 10;
+    private static final int MAX_SIZE = 50;
 
     private int page = 1;
     private int size = 10;
     private Sort.Direction direction = Sort.Direction.DESC;
-
+    
     public void setPage(int page) {
         this.page = page <= 0 ? 1 : page;
     }
 
     public void setSize(int size) {
-        int DEFAULT_SIZE = 10;
-        int MAX_SIZE = 50;
         this.size = size > MAX_SIZE ? DEFAULT_SIZE : size;
     }
 
@@ -24,6 +27,9 @@ public class PageRequest {
     }
 
     public org.springframework.data.domain.PageRequest of() {
+        if (size <= 0) {
+            throw new BusinessException(INPUT_INVALID_VALUE);
+        }
         return org.springframework.data.domain.PageRequest.of(page - 1, size, direction, "createdAt");
     }
 }


### PR DESCRIPTION
## 🛠️ 변경사항
- PageRequest의 size가 0보다 작을 경우 예외처리 추가
- GlobalExceptionHandler에 잘못된 클래스가 추가되어 있어 수정했습니다!

- 검색이 제대로 되지 않던 이유는 GetProjectsRequest에 Setter가 없어 쿼리 파라미터로 가져오지 못하고 있었습니다(이 dto 클래스에만 예외적으로 setter를 추가해놓겠습니다).. 그래서 검색 조건들이 다 null로 들어가고 있어 조회가 제대로 되지 않았어요
</br>
</br>

## ☝️ 유의사항

</br>
</br>

## 👀 참고자료

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
