### PR TITLE
feat : 사용자 닉네임으로 마이 페이지 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/graphy/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/member/controller/MemberController.java
@@ -1,10 +1,10 @@
 package com.graphy.backend.domain.member.controller;
 
+import com.graphy.backend.domain.auth.util.annotation.CurrentUser;
 import com.graphy.backend.domain.member.domain.Member;
 import com.graphy.backend.domain.member.dto.response.GetMemberResponse;
 import com.graphy.backend.domain.member.dto.response.GetMyPageResponse;
 import com.graphy.backend.domain.member.service.MemberService;
-import com.graphy.backend.domain.auth.util.annotation.CurrentUser;
 import com.graphy.backend.domain.project.service.ProjectService;
 import com.graphy.backend.global.result.ResultCode;
 import com.graphy.backend.global.result.ResultResponse;
@@ -37,6 +37,13 @@ public class MemberController {
     @GetMapping("/mypage")
     public ResponseEntity<ResultResponse> myPage(@CurrentUser Member member) {
         GetMyPageResponse result = projectService.myPage(member);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.MYPAGE_GET_SUCCESS, result));
+    }
+
+    @Operation(summary = "get myPage by nickname", description = "사용자 닉네임으로 마이페이지 조회")
+    @GetMapping("/mypage/{nickname}")
+    public ResponseEntity<ResultResponse> mypageByNickname(@PathVariable String nickname) {
+        GetMyPageResponse result = projectService.myPageByNickname(nickname);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.MYPAGE_GET_SUCCESS, result));
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/graphy/backend/domain/member/repository/MemberRepository.java
@@ -2,8 +2,6 @@ package com.graphy.backend.domain.member.repository;
 
 import com.graphy.backend.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +9,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
     Optional<Member> findByEmail(String email);
     List<Member> findMemberByNicknameStartingWith(String nickname);
+
+    Optional<Member> findFirstByNickname(String nickname);
 }

--- a/backend/src/main/java/com/graphy/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/member/service/MemberService.java
@@ -49,4 +49,11 @@ public class MemberService {
                 () -> new EmptyResultException(MEMBER_NOT_EXIST)
         );
     }
+
+    public Member findMemberByNickname(String nickname) {
+        return memberRepository.findFirstByNickname(nickname).orElseThrow(
+                () -> new EmptyResultException(MEMBER_NOT_EXIST)
+        );
+    }
+
 }

--- a/backend/src/main/java/com/graphy/backend/domain/project/dto/response/GetProjectInfoResponse.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/dto/response/GetProjectInfoResponse.java
@@ -1,7 +1,10 @@
 package com.graphy.backend.domain.project.dto.response;
 
 import com.graphy.backend.domain.project.domain.Project;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
@@ -13,13 +16,13 @@ public class GetProjectInfoResponse {
 
     private String projectName;
 
-    private String description;
+    private String content;
 
     public static GetProjectInfoResponse from(Project project) {
         return GetProjectInfoResponse.builder()
                 .id(project.getId())
                 .projectName(project.getProjectName())
-                .description(project.getDescription())
+                .content(project.getContent())
                 .build();
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
@@ -13,6 +13,7 @@ import com.graphy.backend.domain.project.dto.request.GetProjectsRequest;
 import com.graphy.backend.domain.project.dto.request.UpdateProjectRequest;
 import com.graphy.backend.domain.project.dto.response.*;
 import com.graphy.backend.domain.project.repository.ProjectRepository;
+import com.graphy.backend.domain.project.repository.TagRepository;
 import com.graphy.backend.global.chatgpt.dto.GptCompletionDto.GptCompletionRequest;
 import com.graphy.backend.global.chatgpt.dto.GptCompletionDto.GptCompletionResponse;
 import com.graphy.backend.global.chatgpt.service.GPTChatRestService;
@@ -46,6 +47,7 @@ public class ProjectService {
     private final CommentService commentService;
     private final TagService tagService;
     private final GPTChatRestService gptChatRestService;
+    private final TagRepository tagRepository;
 
 //    @PostConstruct
 //    public void initTag() throws IOException {
@@ -120,6 +122,12 @@ public class ProjectService {
     }
 
     public GetMyPageResponse myPage(Member member) {
+        List<GetProjectInfoResponse> projectInfoList = this.findProjectInfoList(member.getId());
+        return GetMyPageResponse.of(member, projectInfoList);
+    }
+
+    public GetMyPageResponse myPageByNickname(String nickname) {
+        Member member = memberService.findMemberByNickname(nickname);
         List<GetProjectInfoResponse> projectInfoList = this.findProjectInfoList(member.getId());
         return GetMyPageResponse.of(member, projectInfoList);
     }

--- a/backend/src/main/java/com/graphy/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/graphy/backend/global/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                         "/api/v1/auth/signin",
                         "/api/v1/auth/logout",
                         "/api/v1/projects", 
+                        "/api/v1/members/**",
                         "/swagger-ui/**").permitAll()
                 .antMatchers(HttpMethod.GET, "/api/v1/projects/{projectId}").permitAll()
                 .antMatchers(HttpMethod.GET, "/api/v1/comments/{commentId}").permitAll()

--- a/backend/src/test/java/com/graphy/backend/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/member/controller/MemberControllerTest.java
@@ -24,10 +24,11 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -133,8 +134,8 @@ class MemberControllerTest extends MockApiTest {
                 .followerCount(member1.getFollowerCount())
                 .followingCount(member1.getFollowingCount())
                 .getProjectInfoResponseList(Arrays.asList(
-                        GetProjectInfoResponse.builder().id(1L).projectName("project1").description("description1").build(),
-                        GetProjectInfoResponse.builder().id(2L).projectName("project2").description("description2").build()
+                        GetProjectInfoResponse.builder().id(1L).projectName("project1").content("content1").build(),
+                        GetProjectInfoResponse.builder().id(2L).projectName("project2").content("content2").build()
                 ))
                 .build();
 

--- a/backend/src/test/java/com/graphy/backend/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/member/controller/MemberControllerTest.java
@@ -157,11 +157,11 @@ class MemberControllerTest extends MockApiTest {
 
                 .andExpect(jsonPath("$.data.getProjectInfoResponseList[0].id").value(1))
                 .andExpect(jsonPath("$.data.getProjectInfoResponseList[0].projectName").value("project1"))
-                .andExpect(jsonPath("$.data.getProjectInfoResponseList[0].description").value("description1"))
+                .andExpect(jsonPath("$.data.getProjectInfoResponseList[0].content").value("content1"))
 
                 .andExpect(jsonPath("$.data.getProjectInfoResponseList[1].id").value(2))
                 .andExpect(jsonPath("$.data.getProjectInfoResponseList[1].projectName").value("project2"))
-                .andExpect(jsonPath("$.data.getProjectInfoResponseList[1].description").value("description2"))
+                .andExpect(jsonPath("$.data.getProjectInfoResponseList[1].content").value("content2"))
 
                 .andDo(document("members/myPage/find/success",
                         responseFields(
@@ -177,7 +177,7 @@ class MemberControllerTest extends MockApiTest {
 
                                 fieldWithPath("data.getProjectInfoResponseList[].id").description("프로젝트 ID"),
                                 fieldWithPath("data.getProjectInfoResponseList[].projectName").description("프로젝트 이름"),
-                                fieldWithPath("data.getProjectInfoResponseList[].description").description("프로젝트 설명")
+                                fieldWithPath("data.getProjectInfoResponseList[].content").description("프로젝트 소개")
                         )));
     }
 }

--- a/backend/src/test/java/com/graphy/backend/domain/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/project/service/ProjectServiceTest.java
@@ -202,7 +202,7 @@ class ProjectServiceTest extends MockTest {
                 .projectName("project1")
                 .description("description1")
                 .thumbNail("thumb")
-                .content("content")
+                .content("content1")
                 .build();
 
         Project project2 = Project.builder()
@@ -211,19 +211,19 @@ class ProjectServiceTest extends MockTest {
                 .projectName("project2")
                 .description("description2")
                 .thumbNail("thumb")
-                .content("content")
+                .content("content2")
                 .build();
 
         GetProjectInfoResponse response1 = GetProjectInfoResponse.builder()
                 .id(1L)
                 .projectName("project1")
-                .description("description1")
+                .content("content1")
                 .build();
 
         GetProjectInfoResponse response2 = GetProjectInfoResponse.builder()
                 .id(2L)
                 .projectName("project2")
-                .description("description2")
+                .content("content2")
                 .build();
 
         List<GetProjectInfoResponse> responseList = Arrays.asList(response1, response2);


### PR DESCRIPTION
## 🛠️ 변경사항
- 유저 이름으로 조회하는 마이페이지 API
- 마이페이지, 유저 조회 API 인가 요청 X
- 마이페이지 응답 DTO 한 줄 소개를 글 본문 내용으로 변경
</br>
</br>

## ☝️ 유의사항

</br>
</br>

## 👀 참고자료

</br>
</br>

## ❗체크리스트
- [ ] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [ ] 수정 가능하도록 유연하게 작성했나요?
- [ ] 필요 없는 import문이나 setter 등을 삭제했나요?
- [ ] 기존의 코드에 영향이 없는 것을 확인하였나요?
