### PR TITLE
BE/#270 프로젝트 상세 조회 시, 조회수 증가 구현

### DIFF
--- a/backend/src/main/java/com/graphy/backend/domain/comment/domain/Bookmark.java
+++ b/backend/src/main/java/com/graphy/backend/domain/comment/domain/Bookmark.java
@@ -1,4 +1,4 @@
-package com.graphy.backend.domain.bookmark.domain;
+package com.graphy.backend.domain.comment.domain;
 
 import com.graphy.backend.domain.member.domain.Member;
 import com.graphy.backend.domain.recruitment.domain.Recruitment;

--- a/backend/src/main/java/com/graphy/backend/domain/job/controller/JobController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/job/controller/JobController.java
@@ -2,19 +2,22 @@ package com.graphy.backend.domain.job.controller;
 
 import com.graphy.backend.domain.job.dto.response.GetJobResponse;
 import com.graphy.backend.domain.job.service.JobService;
-import com.graphy.backend.global.common.PageRequest;
+import com.graphy.backend.global.common.dto.PageRequest;
 import com.graphy.backend.global.error.ErrorCode;
 import com.graphy.backend.global.error.exception.EmptyResultException;
 import com.graphy.backend.global.result.ResultCode;
 import com.graphy.backend.global.result.ResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "EmploymentController", description = "신규 채용 공고 API")
 @RestController

--- a/backend/src/main/java/com/graphy/backend/domain/message/controller/MessageController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/message/controller/MessageController.java
@@ -6,7 +6,7 @@ import com.graphy.backend.domain.message.dto.request.CreateMessageRequest;
 import com.graphy.backend.domain.message.dto.response.GetMessageDetailResponse;
 import com.graphy.backend.domain.message.dto.response.GetMessageResponse;
 import com.graphy.backend.domain.message.service.MessageService;
-import com.graphy.backend.global.common.PageRequest;
+import com.graphy.backend.global.common.dto.PageRequest;
 import com.graphy.backend.global.result.ResultCode;
 import com.graphy.backend.global.result.ResultResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/backend/src/main/java/com/graphy/backend/domain/notification/controller/NotificationController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/notification/controller/NotificationController.java
@@ -4,7 +4,7 @@ import com.graphy.backend.domain.auth.util.annotation.CurrentUser;
 import com.graphy.backend.domain.member.domain.Member;
 import com.graphy.backend.domain.notification.dto.response.GetNotificationResponse;
 import com.graphy.backend.domain.notification.service.NotificationService;
-import com.graphy.backend.global.common.PageRequest;
+import com.graphy.backend.global.common.dto.PageRequest;
 import com.graphy.backend.global.result.ResultCode;
 import com.graphy.backend.global.result.ResultResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/backend/src/main/java/com/graphy/backend/domain/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/notification/service/NotificationService.java
@@ -6,7 +6,7 @@ import com.graphy.backend.domain.notification.domain.Notification;
 import com.graphy.backend.domain.notification.dto.NotificationDto;
 import com.graphy.backend.domain.notification.dto.response.GetNotificationResponse;
 import com.graphy.backend.domain.notification.repository.NotificationRepository;
-import com.graphy.backend.global.common.PageRequest;
+import com.graphy.backend.global.common.dto.PageRequest;
 import com.graphy.backend.global.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/controller/ProjectController.java
@@ -1,5 +1,6 @@
 package com.graphy.backend.domain.project.controller;
 
+import com.graphy.backend.domain.auth.util.annotation.CurrentUser;
 import com.graphy.backend.domain.member.domain.Member;
 import com.graphy.backend.domain.project.dto.request.CreateProjectRequest;
 import com.graphy.backend.domain.project.dto.request.GetProjectPlanRequest;
@@ -10,8 +11,7 @@ import com.graphy.backend.domain.project.dto.response.GetProjectDetailResponse;
 import com.graphy.backend.domain.project.dto.response.GetProjectResponse;
 import com.graphy.backend.domain.project.dto.response.UpdateProjectResponse;
 import com.graphy.backend.domain.project.service.ProjectService;
-import com.graphy.backend.domain.auth.util.annotation.CurrentUser;
-import com.graphy.backend.global.common.PageRequest;
+import com.graphy.backend.global.common.dto.PageRequest;
 import com.graphy.backend.global.error.ErrorCode;
 import com.graphy.backend.global.error.exception.EmptyResultException;
 import com.graphy.backend.global.result.ResultCode;
@@ -22,13 +22,18 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
 @Tag(name = "ProjectController", description = "프로젝트 관련 API")
 @RestController
@@ -86,9 +91,17 @@ public class ProjectController {
 
     @Operation(summary = "findProject", description = "프로젝트 상세 조회")
     @GetMapping("/{projectId}")
-    public ResponseEntity<ResultResponse> projectDetails(@PathVariable Long projectId) {
+    public ResponseEntity<ResultResponse> projectDetails(@PathVariable Long projectId, HttpServletRequest request) {
         GetProjectDetailResponse result = projectService.findProjectById(projectId);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.PROJECT_GET_SUCCESS, result));
+        Cookie cookie = projectService.addViewCount(request, projectId);
+        ResponseCookie responseCookie = ResponseCookie.from(cookie.getName(), cookie.getValue())
+                .path(cookie.getPath())
+                .maxAge(cookie.getMaxAge())
+                .build();
+
+        return ResponseEntity.ok()
+                .header(SET_COOKIE, responseCookie.toString())
+                .body(ResultResponse.of(ResultCode.PROJECT_GET_SUCCESS, result));
     }
 
     @Operation(summary = "getProjectPlan", description = "프로젝트 고도화 계획 제안")

--- a/backend/src/main/java/com/graphy/backend/domain/project/domain/Project.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/domain/Project.java
@@ -53,9 +53,13 @@ public class Project extends BaseEntity {
 
     private String thumbNail;
 
-    @Column(nullable = true)
+    @Column(nullable = false)
     @ColumnDefault("0")
     private int likeCount = 0;
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private int viewCount = 0;
 
     public void updateProject(String projectName, String content,
                               String description, Tags tags,
@@ -70,6 +74,9 @@ public class Project extends BaseEntity {
 
     public void updateLikeCount(int amount) {
         this.likeCount += amount;
+    }
+    public void addViewCount() {
+        this.viewCount++;
     }
 
     public void addTag(Tags tags) {

--- a/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/service/ProjectService.java
@@ -21,7 +21,6 @@ import com.graphy.backend.global.error.exception.EmptyResultException;
 import com.graphy.backend.global.error.exception.LongRequestException;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,6 +28,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -36,7 +37,8 @@ import java.util.stream.Collectors;
 
 import static com.graphy.backend.global.config.ChatGPTConfig.MAX_REQUEST_TOKEN;
 
-@Service @Slf4j
+@Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProjectService {
     private final ProjectRepository projectRepository;
@@ -94,12 +96,42 @@ public class ProjectService {
     }
 
     public GetProjectDetailResponse findProjectById(Long projectId) {
-        Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new EmptyResultException(ErrorCode.PROJECT_DELETED_OR_NOT_EXIST));
-
+        Project project = this.getProjectById(projectId);
         List<GetCommentWithMaskingResponse> comments = commentService.findCommentListWithMasking(projectId);
-
         return GetProjectDetailResponse.of(project, comments);
+    }
+
+    @Transactional
+    public Cookie addViewCount(HttpServletRequest request, Long projectId) {
+        Project project = this.getProjectById(projectId);
+
+        Cookie[] cookies = request.getCookies();
+        Cookie oldCookie = this.findCookie(cookies, "View_Count");
+
+        if (oldCookie != null) {
+            if (!oldCookie.getValue().contains("[" + projectId + "]")) {
+                oldCookie.setValue(oldCookie.getValue() + "[" + projectId + "]");
+                project.addViewCount();
+            }
+            oldCookie.setPath("/");
+            return oldCookie;
+        } else {
+            Cookie newCookie = new Cookie("View_Count", "[" + projectId + "]");
+            newCookie.setPath("/");
+            project.addViewCount();
+            return newCookie;
+        }
+    }
+
+    private Cookie findCookie(Cookie[] cookies, String cookieName) {
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookieName.equals(cookie.getName())) {
+                    return cookie;
+                }
+            }
+        }
+        return null;
     }
 
     public List<GetProjectResponse> findProjectList(GetProjectsRequest dto, Pageable pageable) {
@@ -144,9 +176,7 @@ public class ProjectService {
     }
 
     private void GptApiCall(GptCompletionRequest request, Consumer<String> callback) {
-        log.info("비동기 작업 시작");
         GptCompletionResponse result = gptChatRestService.completion(request);
-        log.info("비동기 작업 완료");
         String response = result.getMessages().get(0).getText()
                 .replace("\n", " ").replace("\n\n", " ");
         callback.accept(response);

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/controller/RecruitmentController.java
@@ -9,7 +9,7 @@ import com.graphy.backend.domain.recruitment.dto.response.GetApplicationResponse
 import com.graphy.backend.domain.recruitment.dto.response.GetRecruitmentDetailResponse;
 import com.graphy.backend.domain.recruitment.dto.response.GetRecruitmentResponse;
 import com.graphy.backend.domain.recruitment.service.RecruitmentService;
-import com.graphy.backend.global.common.PageRequest;
+import com.graphy.backend.global.common.dto.PageRequest;
 import com.graphy.backend.global.result.ResultCode;
 import com.graphy.backend.global.result.ResultResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/backend/src/main/java/com/graphy/backend/global/common/dto/PageRequest.java
+++ b/backend/src/main/java/com/graphy/backend/global/common/dto/PageRequest.java
@@ -1,4 +1,4 @@
-package com.graphy.backend.global.common;
+package com.graphy.backend.global.common.dto;
 
 import com.graphy.backend.global.error.exception.BusinessException;
 import org.springframework.data.domain.Sort;

--- a/backend/src/test/java/com/graphy/backend/domain/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/project/service/ProjectServiceTest.java
@@ -16,7 +16,7 @@ import com.graphy.backend.domain.project.dto.response.GetProjectInfoResponse;
 import com.graphy.backend.domain.project.dto.response.GetProjectResponse;
 import com.graphy.backend.domain.project.dto.response.UpdateProjectResponse;
 import com.graphy.backend.domain.project.repository.ProjectRepository;
-import com.graphy.backend.global.common.PageRequest;
+import com.graphy.backend.global.common.dto.PageRequest;
 import com.graphy.backend.global.error.ErrorCode;
 import com.graphy.backend.global.error.exception.EmptyResultException;
 import com.graphy.backend.test.MockTest;

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -45,6 +45,7 @@ create table project
     content      longtext      null,
     description  varchar(255)  null,
     like_count   int default 0 null,
+    view_count   int default 0 null,
     project_name varchar(255)  not null,
     thumb_nail   varchar(255)  null,
     member_id    bigint        not null,


### PR DESCRIPTION
## 🛠️ 변경사항
- 프로젝트 상세 조회 API 호출 시 조회수를 증가하도록 했습니다(자세한 내용은 참고자료 참고)
- project 엔티티에 조회수 컬럼 추가
- ProjectService 
    - 쿠키 탐색하는 findCookie()  추가
    - 쿠키 값에 따른 조회수 증가 로직 진행하는 addViewCount() 추가
</br>
</br>

## ☝️ 유의사항

</br>
</br>

## 👀 참고자료
https://velog.io/@kimhalin/%EC%A1%B0%ED%9A%8C%EC%88%98-%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0
</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
