### PR TITLE
Be/#272 Prometheus에 Slack 알림 alertmanager 연동

### DIFF
--- a/alertmanager/config.yml
+++ b/alertmanager/config.yml
@@ -1,5 +1,5 @@
 global:
-  slack_api_url: ${SLACK_WEBHOOK}
+  slack_api_url: 'https://hooks.slack.com/services/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'
 
 route:
   receiver: 'slack-notifications'

--- a/alertmanager/config.yml
+++ b/alertmanager/config.yml
@@ -1,0 +1,13 @@
+global:
+  slack_api_url: ${SLACK_WEBHOOK}
+
+route:
+  receiver: 'slack-notifications'
+  repeat_interval: 2m
+receivers:
+  - name: 'slack-notifications'
+    slack_configs:
+      - channel: '#_monitoring'
+        send_resolved: true
+        title: "{{ range .Alerts }}{{ .Annotations.summary }}\n{{ end }}"
+        text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,3 +78,15 @@ services:
     depends_on:
       - prometheus
       - springboot
+
+  alertmanager:
+    image: prom/alertmanager
+    container_name: alert-manager
+    ports:
+      - 9093:9093
+    volumes:
+      - ./alertmanager/:/etc/alertmanager/
+    restart: always
+    command:
+      - "--config.file=/etc/alertmanager/config.yml"
+      - "--storage.path=/alertmanager"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,8 @@ services:
       - ./prometheus/data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
+    links:
+      - alertmanager:alertmanager
     depends_on:
       - springboot
 

--- a/prometheus/alert.rules
+++ b/prometheus/alert.rules
@@ -1,0 +1,48 @@
+groups:
+- name: alert.rules
+  rules:
+  - alert: InstanceDown
+    expr: up == 0
+    for: 1m
+    labels:
+      severity: "critical"
+    annotations:
+      summary: "Endpoint {{ $labels.instance }}"
+      identifier: "{{ $labels.instance }}"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 1 minutes."
+
+  - alert: HostOutOfMemory
+    expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes * 100 < 10
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Host out of memory (instance {{ $labels.instance }})"
+      description: "Node memory is filling up (< 10% left)\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
+
+  - alert: HostMemoryUnderMemoryPressure
+    expr: rate(node_vmstat_pgmajfault[1m]) > 1000
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Host memory under memory pressure (instance {{ $labels.instance }})"
+      description: "The node is under heavy memory pressure. High rate of major page faults\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
+
+  - alert: HostOutOfDiskSpace
+    expr: (node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes < 10 and ON (instance, device, mountpoint) node_filesystem_readonly == 0
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Host out of disk space (instance {{ $labels.instance }})"
+      description: "Disk is almost full (< 10% left)\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
+
+  - alert: HostHighCpuLoad
+    expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[2m])) * 100) > 80
+    for: 0m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Host high CPU load (instance {{ $labels.instance }})"
+      description: "CPU load is > 80%\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -9,6 +9,7 @@ alerting:
         - targets: ["alertmanager:9093"]
 
 rule_files:
+  - 'alert.rules'
 
 scrape_configs:
   - job_name: "prometheus"

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -4,8 +4,9 @@ global:
 
 alerting:
   alertmanagers:
+    - scheme: http
     - static_configs:
-        - targets:
+        - targets: ["alertmanager:9093"]
 
 rule_files:
 


### PR DESCRIPTION
## 🛠️ 변경사항

docker-compose.yml에 alertmanager 추가, prometheus에 link로 alertmanager 추가
alertmanager를 관리할 config.yml 생성

<img width="625" alt="스크린샷 2023-11-07 오후 5 47 03" src="https://github.com/techeer-sv/graphy/assets/76465887/99ce18a5-e2bc-412a-8ecf-71a447b6dcc8">
테스트사진

## ☝️ 유의사항

**알림이 오는 상황**
1. 어떤 인스턴스가 1분 동안 다운되어 있을 때
2. 시스템 메모리가 10% 미만으로 남았을 때
3. 시스템이 메모리 압박 상태에 있을 때 (주요 페이지 결함의 비율이 높을 때)
4. 디스크 공간이 10% 미만으로 남았을 때
5. CPU 부하가 80%를 초과했을 때

## 👀 참고자료

https://velog.io/@king/slack-incoming-webhook

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
