### PR TITLE
Be/#288 MyPage API 수정

### DIFF
--- a/backend/src/main/java/com/graphy/backend/domain/member/dto/response/GetMyPageResponse.java
+++ b/backend/src/main/java/com/graphy/backend/domain/member/dto/response/GetMyPageResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
 public class GetMyPageResponse {
+    private Long id;
     private String nickname;
     private String introduction;
     private int followerCount;
@@ -20,6 +21,7 @@ public class GetMyPageResponse {
     public static GetMyPageResponse of(Member member,
                                        List<GetProjectInfoResponse> getProjectInfoResponseList) {
         return GetMyPageResponse.builder()
+                .id(member.getId())
                 .nickname(member.getNickname())
                 .introduction(member.getIntroduction())
                 .followerCount(member.getFollowerCount())

--- a/backend/src/test/java/com/graphy/backend/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/graphy/backend/domain/member/controller/MemberControllerTest.java
@@ -129,6 +129,7 @@ class MemberControllerTest extends MockApiTest {
     @DisplayName("현재 로그인한 사용자의 정보로 마이페이지를 조회한다")
     void getMyPageTest() throws Exception {
         GetMyPageResponse result = GetMyPageResponse.builder()
+                .id(member1.getId())
                 .nickname(member1.getNickname())
                 .introduction(member1.getIntroduction())
                 .followerCount(member1.getFollowerCount())
@@ -149,6 +150,7 @@ class MemberControllerTest extends MockApiTest {
                 .andDo(print())
                 .andExpect(status().isOk())
 
+                .andExpect(jsonPath("$.data.id").value((member1.getId())))
                 .andExpect(jsonPath("$.data.nickname").value(member1.getNickname()))
                 .andExpect(jsonPath("$.data.introduction").value(member1.getIntroduction()))
                 .andExpect(jsonPath("$.data.followerCount").value(member1.getFollowerCount()))
@@ -169,6 +171,7 @@ class MemberControllerTest extends MockApiTest {
                                 fieldWithPath("message").description("응답 메시지"),
                                 fieldWithPath("data").description("응답 데이터"),
 
+                                fieldWithPath("data.id").description("유저 PK"),
                                 fieldWithPath("data.nickname").description("닉네임"),
                                 fieldWithPath("data.introduction").description("본인 소개"),
                                 fieldWithPath("data.followerCount").description("팔로워 수"),


### PR DESCRIPTION
## 🛠️ 변경사항

GetMyPageResponse에서 member의 id를 리턴하도록 변경
테스트 코드 : 바뀐 GetMyPageResponse에 맞게 수정

## ☝️ 유의사항

</br>
</br>

## 👀 참고자료

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
