### PR TITLE
구인공고 리스트 API 모집여부 출력 및 모집 중 필터링 추가

### DIFF
--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/controller/RecruitmentController.java
@@ -56,9 +56,10 @@ public class RecruitmentController {
     public ResponseEntity<ResultResponse> recruitmentList(@RequestParam(required = false) List<Position> positions,
                                                           @RequestParam(required = false) List<String> tags,
                                                           @RequestParam(required = false) String keyword,
+                                                          @RequestParam(required = false) Boolean isRecruiting,
                                                           PageRequest pageRequest) {
         Pageable pageable = pageRequest.of();
-        List<GetRecruitmentResponse> result = recruitmentService.findRecruitmentList(positions, tags, keyword, pageable);
+        List<GetRecruitmentResponse> result = recruitmentService.findRecruitmentList(positions, tags, keyword, isRecruiting, pageable);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.RECRUITMENT_PAGING_GET_SUCCESS, result));
     }
 

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/controller/RecruitmentController.java
@@ -46,11 +46,7 @@ public class RecruitmentController {
         GetRecruitmentDetailResponse result = recruitmentService.findRecruitmentById(recruitmentId);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.RECRUITMENT_GET_SUCCESS, result));
     }
-
-    /**
-     * 모집 여부 필터링
-     * 모집 중 필터링
-     */
+    
     @Operation(summary = "findRecruitmentList", description = "구인 게시글 조회")
     @GetMapping
     public ResponseEntity<ResultResponse> recruitmentList(@RequestParam(required = false) List<Position> positions,

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
@@ -49,8 +49,8 @@ public class Recruitment extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime period;
 
-    @Column(nullable = true)
-    private boolean isRecruiting;
+    @Column(nullable = false)
+    private boolean isRecruiting = true;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -86,7 +86,7 @@ public class Recruitment extends BaseEntity {
         addTag(tags);
     }
 
-    public boolean getIsRecruiting() {
-        return LocalDateTime.now().isBefore(this.endDate);  
-    }
+//    public boolean IsRecruiting() {
+//        return LocalDateTime.now().isBefore(this.endDate);
+//    }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
@@ -82,12 +82,9 @@ public class Recruitment extends BaseEntity {
         this.recruitmentCount = request.getRecruitmentCount();
         this.type = request.getType();
         this.endDate = request.getEndDate();
+        this.isRecruiting = request.isRecruiting();
         this.position = request.getPosition();
         recruitmentTags.clear();
         addTag(tags);
     }
-
-//    public boolean IsRecruiting() {
-//        return LocalDateTime.now().isBefore(this.endDate);
-//    }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
@@ -49,6 +49,7 @@ public class Recruitment extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime period;
 
+    @Builder.Default
     @Column(nullable = false)
     private boolean isRecruiting = true;
 

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
@@ -49,9 +49,13 @@ public class Recruitment extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime period;
 
-    @Builder.Default
     @Column(nullable = false)
-    private boolean isRecruiting = true;
+    private Boolean isRecruiting;
+
+    @PrePersist
+    private void initIsRecruiting() {
+        this.isRecruiting = LocalDateTime.now().isBefore(this.endDate);
+    }
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -82,7 +86,7 @@ public class Recruitment extends BaseEntity {
         this.recruitmentCount = request.getRecruitmentCount();
         this.type = request.getType();
         this.endDate = request.getEndDate();
-        this.isRecruiting = request.isRecruiting();
+        this.isRecruiting = request.getIsRecruiting();
         this.position = request.getPosition();
         recruitmentTags.clear();
         addTag(tags);

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
@@ -49,6 +49,9 @@ public class Recruitment extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime period;
 
+    @Column(nullable = false)
+    private boolean isRecruiting;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Position position;

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
@@ -49,7 +49,7 @@ public class Recruitment extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime period;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private boolean isRecruiting;
 
     @Enumerated(EnumType.STRING)

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
@@ -85,4 +85,8 @@ public class Recruitment extends BaseEntity {
         recruitmentTags.clear();
         addTag(tags);
     }
+
+    public boolean isRecruiting() {
+        return LocalDateTime.now().isBefore(this.endDate);  
+    }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/domain/Recruitment.java
@@ -86,7 +86,7 @@ public class Recruitment extends BaseEntity {
         addTag(tags);
     }
 
-    public boolean isRecruiting() {
+    public boolean getIsRecruiting() {
         return LocalDateTime.now().isBefore(this.endDate);  
     }
 }

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/request/UpdateRecruitmentRequest.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/request/UpdateRecruitmentRequest.java
@@ -34,7 +34,7 @@ public class UpdateRecruitmentRequest {
     private LocalDateTime period;
 
     @NotNull(message = "isRecruiting cannot be null")
-    private boolean isRecruiting;
+    private Boolean isRecruiting;
 
     @NotNull(message = "position cannot be null")
     private Position position;

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/request/UpdateRecruitmentRequest.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/request/UpdateRecruitmentRequest.java
@@ -33,6 +33,9 @@ public class UpdateRecruitmentRequest {
     @NotNull(message = "period cannot be null")
     private LocalDateTime period;
 
+    @NotNull(message = "isRecruiting cannot be null")
+    private boolean isRecruiting;
+
     @NotNull(message = "position cannot be null")
     private Position position;
 

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentDetailResponse.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentDetailResponse.java
@@ -46,7 +46,7 @@ public class GetRecruitmentDetailResponse {
                 .period(recruitment.getPeriod())
                 .position(recruitment.getPosition())
                 .recruitmentCount(recruitment.getRecruitmentCount())
-                .isRecruiting(recruitment.isRecruiting())
+                .isRecruiting(recruitment.getIsRecruiting())
                 .techTags(recruitment.getTagNames())
                 .build();
     }

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentDetailResponse.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentDetailResponse.java
@@ -46,7 +46,7 @@ public class GetRecruitmentDetailResponse {
                 .period(recruitment.getPeriod())
                 .position(recruitment.getPosition())
                 .recruitmentCount(recruitment.getRecruitmentCount())
-                .isRecruiting(recruitment.getIsRecruiting())
+                .isRecruiting(recruitment.isRecruiting())
                 .techTags(recruitment.getTagNames())
                 .build();
     }

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentDetailResponse.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentDetailResponse.java
@@ -32,6 +32,8 @@ public class GetRecruitmentDetailResponse {
 
     private Integer recruitmentCount;
 
+    private boolean isRecruiting;
+
     private List<String> techTags;
 
     public static GetRecruitmentDetailResponse from(Recruitment recruitment) {
@@ -44,6 +46,7 @@ public class GetRecruitmentDetailResponse {
                 .period(recruitment.getPeriod())
                 .position(recruitment.getPosition())
                 .recruitmentCount(recruitment.getRecruitmentCount())
+                .isRecruiting(recruitment.isRecruiting())
                 .techTags(recruitment.getTagNames())
                 .build();
     }

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentResponse.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentResponse.java
@@ -2,6 +2,7 @@ package com.graphy.backend.domain.recruitment.dto.response;
 
 import com.graphy.backend.domain.recruitment.domain.Position;
 import com.graphy.backend.domain.recruitment.domain.Recruitment;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,14 +25,18 @@ public class GetRecruitmentResponse {
 
     private Position position;
 
+    private boolean isRecruiting;
+
     private List<String> techTags;
 
     public static GetRecruitmentResponse from(Recruitment recruitment) {
+        boolean isRecruiting = LocalDateTime.now().isBefore(recruitment.getEndDate());
         return GetRecruitmentResponse.builder()
                 .id(recruitment.getId())
                 .nickname(recruitment.getMember().getNickname())
                 .title(recruitment.getTitle())
                 .position(recruitment.getPosition())
+                .isRecruiting(isRecruiting)
                 .techTags(recruitment.getTagNames())
                 .build();
     }

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentResponse.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentResponse.java
@@ -35,7 +35,7 @@ public class GetRecruitmentResponse {
                 .nickname(recruitment.getMember().getNickname())
                 .title(recruitment.getTitle())
                 .position(recruitment.getPosition())
-                .isRecruiting(recruitment.isRecruiting())
+                .isRecruiting(recruitment.getIsRecruiting())
                 .techTags(recruitment.getTagNames())
                 .build();
     }

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentResponse.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentResponse.java
@@ -30,13 +30,12 @@ public class GetRecruitmentResponse {
     private List<String> techTags;
 
     public static GetRecruitmentResponse from(Recruitment recruitment) {
-        boolean isRecruiting = LocalDateTime.now().isBefore(recruitment.getEndDate());
         return GetRecruitmentResponse.builder()
                 .id(recruitment.getId())
                 .nickname(recruitment.getMember().getNickname())
                 .title(recruitment.getTitle())
                 .position(recruitment.getPosition())
-                .isRecruiting(isRecruiting)
+                .isRecruiting(recruitment.isRecruiting())
                 .techTags(recruitment.getTagNames())
                 .build();
     }

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentResponse.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/dto/response/GetRecruitmentResponse.java
@@ -35,7 +35,7 @@ public class GetRecruitmentResponse {
                 .nickname(recruitment.getMember().getNickname())
                 .title(recruitment.getTitle())
                 .position(recruitment.getPosition())
-                .isRecruiting(recruitment.getIsRecruiting())
+                .isRecruiting(recruitment.isRecruiting())
                 .techTags(recruitment.getTagNames())
                 .build();
     }

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/repository/RecruitmentCustomRepository.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/repository/RecruitmentCustomRepository.java
@@ -11,6 +11,7 @@ public interface RecruitmentCustomRepository {
     List<Recruitment> findRecruitments(List<Position> positions,
                                        List<String> tags,
                                        String keyword,
+                                       Boolean isRecruiting,
                                        Pageable pageable);
 
     Optional<Recruitment> findRecruitmentWithMember(Long recruitmentId);

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/repository/custom/RecruitmentCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/repository/custom/RecruitmentCustomRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.graphy.backend.domain.recruitment.domain.Recruitment;
 import com.graphy.backend.domain.recruitment.repository.RecruitmentCustomRepository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 
@@ -24,13 +25,16 @@ public class RecruitmentCustomRepositoryImpl implements RecruitmentCustomReposit
     public List<Recruitment> findRecruitments(List<Position> positions,
                                               List<String> tags,
                                               String title,
+                                              Boolean isRecruiting,
                                               Pageable pageable) {
+
         return jpaQueryFactory
                 .selectFrom(recruitment)
                 .where(
                         tagIn(tags),
                         positionIn(positions),
-                        recruitmentTitleLike(title)
+                        recruitmentTitleLike(title),
+                        isRecruiting(isRecruiting)
                 )
                 .join(recruitment.member, member).fetchJoin()
                 .leftJoin(recruitmentTag).on(recruitmentTag.recruitment.eq(recruitment))
@@ -61,6 +65,12 @@ public class RecruitmentCustomRepositoryImpl implements RecruitmentCustomReposit
 
     private BooleanExpression recruitmentTitleLike(String title) {
         return title != null ? recruitment.title.like(title) : null;
+    }
+
+    private BooleanExpression isRecruiting(Boolean isRecruiting) {
+        if (isRecruiting == null) return null;
+        LocalDateTime now = LocalDateTime.now();
+        return isRecruiting ? recruitment.endDate.after(now) : recruitment.endDate.before(now);
     }
 }
 

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/repository/custom/RecruitmentCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/repository/custom/RecruitmentCustomRepositoryImpl.java
@@ -68,9 +68,8 @@ public class RecruitmentCustomRepositoryImpl implements RecruitmentCustomReposit
     }
 
     private BooleanExpression isRecruiting(Boolean isRecruiting) {
-        if (isRecruiting == null) return null;
-        LocalDateTime now = LocalDateTime.now();
-        return isRecruiting ? recruitment.endDate.after(now) : recruitment.endDate.before(now);
+        if(isRecruiting == null) return null;
+        return recruitment.isRecruiting.eq(isRecruiting);
     }
 }
 

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/service/RecruitmentService.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/service/RecruitmentService.java
@@ -54,8 +54,9 @@ public class RecruitmentService {
     public List<GetRecruitmentResponse> findRecruitmentList(List<Position> positions,
                                                             List<String> tags,
                                                             String keyword,
+                                                            Boolean isRecruiting,
                                                             Pageable pageable) {
-        List<Recruitment> result = recruitmentRepository.findRecruitments(positions, tags, keyword, pageable);
+        List<Recruitment> result = recruitmentRepository.findRecruitments(positions, tags, keyword, isRecruiting, pageable);
         if (result.isEmpty()) throw new EmptyResultException(ErrorCode.RECRUITMENT_NOT_EXIST);
 
         return GetRecruitmentResponse.listOf(result);


### PR DESCRIPTION
## 🛠️ 변경사항

Recruitment 도메인에 isRecruiting(Boolean) 필드 추가
isRecruitment의 메서드를 정의하여 endDate의 값에 따라 동적으로 변경하도록 구현
구인 게시글 리스트 조회 API에 isRecruiting으로 필터링되도록 수정
구인 게시글 상세 조회 API와 구인 게시글 리스트 조회 API에 모집중 여부 출력되도록 구현

![image](https://github.com/techeer-sv/graphy/assets/76465887/6c0c2dcd-a2eb-4271-9f49-0e8e04dddfa2)![image](https://github.com/techeer-sv/graphy/assets/76465887/af01b4d0-3ef1-4add-9b07-839f1ae67386)
<img width="324" alt="image" src="https://github.com/techeer-sv/graphy/assets/76465887/31a181db-359b-4aa9-a486-9b0be1678b66">
![image](https://github.com/techeer-sv/graphy/assets/76465887/248de1f5-a5fe-4cbf-ba99-dc4226912310)


## ☝️ 유의사항

## 👀 참고자료

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
