### PR TITLE
Be/#307 QueryDSL을 사용한 API에서 createdAt으로 정렬안되는 오류 수정

### DIFF
--- a/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/ProjectCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/ProjectCustomRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.graphy.backend.domain.project.repository.custom;
 
 import com.graphy.backend.domain.project.domain.Project;
 import com.graphy.backend.domain.project.repository.ProjectCustomRepository;
+import com.graphy.backend.global.util.QueryDslUtil;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -25,10 +27,12 @@ public class ProjectCustomRepositoryImpl implements ProjectCustomRepository {
 
     @Override
     public Page<Project> searchProjectsWith(Pageable pageable, String projectName, String content) {
+        List<OrderSpecifier> ORDERS = QueryDslUtil.getAllOrderSpecifiers(pageable, project.getMetadata().getName());
         List<Project> fetch = jpaQueryFactory
                 .selectFrom(project).where(projectNameLike(projectName), contentLike(content))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
+                .orderBy(ORDERS.stream().toArray(OrderSpecifier[]::new))
                 .fetch();
 
         JPQLQuery<Project> count = jpaQueryFactory

--- a/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/ProjectCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/ProjectCustomRepositoryImpl.java
@@ -27,12 +27,12 @@ public class ProjectCustomRepositoryImpl implements ProjectCustomRepository {
 
     @Override
     public Page<Project> searchProjectsWith(Pageable pageable, String projectName, String content) {
-        List<OrderSpecifier> ORDERS = QueryDslUtil.getAllOrderSpecifiers(pageable, project.getMetadata().getName());
+        List<OrderSpecifier> orders = QueryDslUtil.getAllOrderSpecifiers(pageable, project.getMetadata().getName());
         List<Project> fetch = jpaQueryFactory
                 .selectFrom(project).where(projectNameLike(projectName), contentLike(content))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(ORDERS.stream().toArray(OrderSpecifier[]::new))
+                .orderBy(orders.stream().toArray(OrderSpecifier[]::new))
                 .fetch();
 
         JPQLQuery<Project> count = jpaQueryFactory

--- a/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/ProjectCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/graphy/backend/domain/project/repository/custom/ProjectCustomRepositoryImpl.java
@@ -45,12 +45,14 @@ public class ProjectCustomRepositoryImpl implements ProjectCustomRepository {
 
     @Override
     public Page<Project> findFollowingProjects(Pageable pageable, Long fromId) {
+        List<OrderSpecifier> orders = QueryDslUtil.getAllOrderSpecifiers(pageable, project.getMetadata().getName());
         List<Project> fetch = jpaQueryFactory.selectFrom(project)
                 .where(project.member.id.in(
                         select(follow.toId).from(follow).where(follow.fromId.eq(fromId)
                 )))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
+                .orderBy(orders.stream().toArray(OrderSpecifier[]::new))
                 .fetch();
         JPAQuery<Long> count = jpaQueryFactory
                 .select(project.count())

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/repository/custom/RecruitmentCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/repository/custom/RecruitmentCustomRepositoryImpl.java
@@ -3,7 +3,9 @@ package com.graphy.backend.domain.recruitment.repository.custom;
 import com.graphy.backend.domain.recruitment.domain.Position;
 import com.graphy.backend.domain.recruitment.domain.Recruitment;
 import com.graphy.backend.domain.recruitment.repository.RecruitmentCustomRepository;
+import com.graphy.backend.global.util.QueryDslUtil;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,8 @@ public class RecruitmentCustomRepositoryImpl implements RecruitmentCustomReposit
                                               Boolean isRecruiting,
                                               Pageable pageable) {
 
+        List<OrderSpecifier> ORDERS = QueryDslUtil.getAllOrderSpecifiers(pageable, recruitment.getMetadata().getName());
+
         return jpaQueryFactory
                 .selectFrom(recruitment)
                 .distinct()
@@ -42,7 +46,9 @@ public class RecruitmentCustomRepositoryImpl implements RecruitmentCustomReposit
                 .leftJoin(recruitmentTag).on(recruitmentTag.recruitment.eq(recruitment))
                 .leftJoin(recruitmentTag.tag, tag)
                 .offset(pageable.getOffset())
+                .orderBy(ORDERS.stream().toArray(OrderSpecifier[]::new))
                 .limit(pageable.getPageSize())
+
                 .fetch();
     }
 

--- a/backend/src/main/java/com/graphy/backend/domain/recruitment/repository/custom/RecruitmentCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/graphy/backend/domain/recruitment/repository/custom/RecruitmentCustomRepositoryImpl.java
@@ -31,7 +31,7 @@ public class RecruitmentCustomRepositoryImpl implements RecruitmentCustomReposit
                                               Boolean isRecruiting,
                                               Pageable pageable) {
 
-        List<OrderSpecifier> ORDERS = QueryDslUtil.getAllOrderSpecifiers(pageable, recruitment.getMetadata().getName());
+        List<OrderSpecifier> orders = QueryDslUtil.getAllOrderSpecifiers(pageable, recruitment.getMetadata().getName());
 
         return jpaQueryFactory
                 .selectFrom(recruitment)
@@ -46,7 +46,7 @@ public class RecruitmentCustomRepositoryImpl implements RecruitmentCustomReposit
                 .leftJoin(recruitmentTag).on(recruitmentTag.recruitment.eq(recruitment))
                 .leftJoin(recruitmentTag.tag, tag)
                 .offset(pageable.getOffset())
-                .orderBy(ORDERS.stream().toArray(OrderSpecifier[]::new))
+                .orderBy(orders.stream().toArray(OrderSpecifier[]::new))
                 .limit(pageable.getPageSize())
 
                 .fetch();

--- a/backend/src/main/java/com/graphy/backend/global/util/QueryDslUtil.java
+++ b/backend/src/main/java/com/graphy/backend/global/util/QueryDslUtil.java
@@ -25,7 +25,7 @@ public class QueryDslUtil {
 
     public static List<OrderSpecifier> getAllOrderSpecifiers(Pageable pageable, String entityType) {
 
-        List<OrderSpecifier> ORDERS = new ArrayList<>();
+        List<OrderSpecifier> orders = new ArrayList<>();
 
         if (!isEmpty(pageable.getSort())) {
             for (Sort.Order order : pageable.getSort()) {
@@ -43,11 +43,11 @@ public class QueryDslUtil {
                             throw new IllegalArgumentException("Entity의 타입이 아닙니다.");
                     }
                     OrderSpecifier<?> orderSpecifier = QueryDslUtil.getSortedColumn(direction, path, "createdAt");
-                    ORDERS.add(orderSpecifier);
+                    orders.add(orderSpecifier);
                 }
             }
         }
 
-        return ORDERS;
+        return orders;
     }
 }

--- a/backend/src/main/java/com/graphy/backend/global/util/QueryDslUtil.java
+++ b/backend/src/main/java/com/graphy/backend/global/util/QueryDslUtil.java
@@ -1,0 +1,53 @@
+package com.graphy.backend.global.util;
+
+import static org.springframework.util.ObjectUtils.isEmpty;
+
+import com.graphy.backend.domain.project.domain.QProject;
+import com.graphy.backend.domain.recruitment.domain.QRecruitment;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.Expressions;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public class QueryDslUtil {
+
+    public static OrderSpecifier<?> getSortedColumn(Order order, Path<?> parent, String fieldName) {
+        Path<Object> fieldPath = Expressions.path(Object.class, parent, fieldName);
+
+        return new OrderSpecifier(order, fieldPath);
+    }
+
+    public static List<OrderSpecifier> getAllOrderSpecifiers(Pageable pageable, String entityType) {
+
+        List<OrderSpecifier> ORDERS = new ArrayList<>();
+
+        if (!isEmpty(pageable.getSort())) {
+            for (Sort.Order order : pageable.getSort()) {
+                if ("createdAt".equals(order.getProperty())) {
+                    Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                    DateTimePath<LocalDateTime> path;
+                    switch (entityType) {
+                        case "recruitment":
+                            path = QRecruitment.recruitment.createdAt;
+                            break;
+                        case "project":
+                            path = QProject.project.createdAt;
+                            break;
+                        default:
+                            throw new IllegalArgumentException("Entity의 타입이 아닙니다.");
+                    }
+                    OrderSpecifier<?> orderSpecifier = QueryDslUtil.getSortedColumn(direction, path, "createdAt");
+                    ORDERS.add(orderSpecifier);
+                }
+            }
+        }
+
+        return ORDERS;
+    }
+}


### PR DESCRIPTION
## 🛠️ 변경사항

QueryDSL을 사용한 조회 API에서 정렬이 안되는 문제 발견
검색해 본 결과, QueryDSL에서 Pagable을 그대로 쓰고는 정렬 불가능

코드 설명 :
- Pageable 객체를 받아 Sort에 정의된 순서대로 엔티티의 특정 필드를 정렬하는 OrderSpecifier 객체 목록 생성
- getSortedColumn 메서드에서 주어진 필드명과 부모 경로를 바탕으로 OrderSpecifier 객체를 생성
- Pageable과 엔티티 타입을 인자로 받아 해당 엔티티에 대한 createdAt 필드를 기준으로 정렬

- 각 CustomRepositoryImpl에는 `List<OrderSpecifier> ORDERS = QueryDslUtil.getAllOrderSpecifiers(pageable, 엔티티 타입);`
- 위와 같이 리스트를 생성하여 `.orderBy(ORDERS.stream().toArray(OrderSpecifier[]::new))` 로 정렬 추가

![image](https://github.com/techeer-sv/graphy/assets/76465887/442d111d-5e3b-4b38-ae7f-7c843ce8fe7f)
![image](https://github.com/techeer-sv/graphy/assets/76465887/b2db785c-87bc-4ee7-a8ae-b6c710735da2)

## ☝️ 유의사항

만약 리스트 조회를 해야하는 엔티티가 또 생기면 QueryDslUtil.java에 case 추가하면 됨

## 👀 참고자료

https://uchupura.tistory.com/7

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
